### PR TITLE
Extract availability probe response time out of the corresponding condition and expose as new metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,11 +26,12 @@ const (
 	metricGardenUsersSum    = "garden_users_total"
 
 	// Shoot metric (available also for Shoots which act as Seed)
-	metricGardenShootInfo           = "garden_shoot_info"
-	metricGardenShootCondition      = "garden_shoot_condition"
-	metricGardenShootOperationState = "garden_shoot_operation_states"
-	metricGardenShootNodeMaxTotal   = "garden_shoot_node_max_total"
-	metricGardenShootNodeMinTotal   = "garden_shoot_node_min_total"
+	metricGardenShootInfo             = "garden_shoot_info"
+	metricGardenShootCondition        = "garden_shoot_condition"
+	metricGardenShootOperationState   = "garden_shoot_operation_states"
+	metricGardenShootNodeMaxTotal     = "garden_shoot_node_max_total"
+	metricGardenShootNodeMinTotal     = "garden_shoot_node_min_total"
+	metricGardenShootResponseDuration = "garden_shoot_response_duration_milliseconds"
 
 	// Aggregated Shoot metrics (exclude Shoots which act as Seed)
 	metricGardenOperationsTotal = "garden_shoot_operations_total"
@@ -41,9 +42,10 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 		metricGardenProjectsSum: prometheus.NewDesc(metricGardenProjectsSum, "Count of projects.", nil, nil),
 		metricGardenUsersSum:    prometheus.NewDesc(metricGardenUsersSum, "Count of users.", nil, nil),
 
-		metricGardenShootInfo:           prometheus.NewDesc(metricGardenShootInfo, "Information to a Shoot.", []string{"name", "project", "iaas", "version", "region", "seed"}, nil),
-		metricGardenShootOperationState: prometheus.NewDesc(metricGardenShootOperationState, "Operation state of a Shoot.", []string{"name", "project", "operation", "mail_to"}, nil),
-		metricGardenShootCondition:      prometheus.NewDesc(metricGardenShootCondition, "Condition state of Shoot.", []string{"name", "project", "condition", "operation", "purpose", "mail_to"}, nil),
+		metricGardenShootInfo:             prometheus.NewDesc(metricGardenShootInfo, "Information to a Shoot.", []string{"name", "project", "iaas", "version", "region", "seed"}, nil),
+		metricGardenShootOperationState:   prometheus.NewDesc(metricGardenShootOperationState, "Operation state of a Shoot.", []string{"name", "project", "operation"}, nil),
+		metricGardenShootCondition:        prometheus.NewDesc(metricGardenShootCondition, "Condition state of Shoot.", []string{"name", "project", "condition", "operation", "purpose", "is_seed"}, nil),
+		metricGardenShootResponseDuration: prometheus.NewDesc(metricGardenShootResponseDuration, "Response time of the Shoot API server. Not provided when not reachable.", []string{"name", "project"}, nil),
 
 		metricGardenShootNodeMaxTotal: prometheus.NewDesc(metricGardenShootNodeMaxTotal, "Max node count of a Shoot.", []string{"name", "project"}, nil),
 		metricGardenShootNodeMinTotal: prometheus.NewDesc(metricGardenShootNodeMinTotal, "Min node count of a Shoot.", []string{"name", "project"}, nil),

--- a/pkg/metrics/user.go
+++ b/pkg/metrics/user.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package metrics
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
The Shoot condition "APIServerAvailable" contains in its message field the response time duration of the executed health probe. The exporter will extract the duration out of the message and expose it as new metric.

**Release note**:
```improvement operator
The metrics-exporter expose now a new metric which contains the duration of the Shoot API server health probe.
```