### PR TITLE
Add custom metrics and metric template

### DIFF
--- a/dashboards/shoot-customization-dashboard.json
+++ b/dashboards/shoot-customization-dashboard.json
@@ -1,0 +1,2374 @@
+{
+  "description": "Dashboard with Information to the amount of custom configured Shoot clusters.",
+  "editable": false,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 44,
+      "title": "General",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Amount of hibernated Shoots.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 8,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_hibernation_enabled_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Hibernated Shoots",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Amount of Shoots which have an hibernation schedule configured.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 17,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_hibernation_schedule_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with Hibernation Schedule",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which allow privileged containers.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 18,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_privileged_containers_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with Privileged Container",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which use a custom dns domain.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 53,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_network_customdomain_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with Custom DNS Domain",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which have a maintenance window configured.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 5
+      },
+      "id": 25,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_maintenance_window_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with Maintenance Window",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which have autoupdate for kubernetes versions configured.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 5
+      },
+      "id": 54,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_maintenance_autoupdate_k8sversion_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with K8S Patch Version Autoupdate",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which have autoupdate for machine image versions configured.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 5
+      },
+      "id": 55,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_maintenance_autoupdate_imageversion_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with Machine Image Version Autoupdate",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "cluster-prometheus",
+      "decimals": 0,
+      "description": "Count of Shoots which have an extension(s) configured.",
+      "fill": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 28,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_extensions_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{extension}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Shoot with Extensions",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "cluster-prometheus",
+      "decimals": 0,
+      "description": "Count of Shoots which by proxy mode configuration for the kube proxy.",
+      "fill": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 29,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_proxy_mode_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{mode}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Shoots Proxy Mode Configurations",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 46,
+      "panels": [],
+      "title": "kube-apiserver",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which have basic auth enabled on the kube apiserver.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 19,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_apiserver_basicauth_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoot apiservers with Basic Auth",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which have an audit log policy configured for the kube apiserver.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 14
+      },
+      "id": 20,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_apiserver_auditpolicy_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoot apiservers with Audit Log Policy",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which have an open id connect coniguration for the kube apiserver.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "id": 21,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_apiserver_oidcconfig_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoot apiservers with OIDC Configuration",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "cluster-prometheus",
+      "decimals": 0,
+      "description": "Count of Shoots with enabled kube apiserver feature gates.",
+      "fill": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 22,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_apiserver_featuregates_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{featuregate}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Shoot apiservers with Feature Gates",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "cluster-prometheus",
+      "decimals": 0,
+      "description": "Count of Shoots with enabled kube apiserver admission plugins.",
+      "fill": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 23,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_apiserver_admissionplugins_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{admissionplugin}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Shoot apiservers with Admission Plugins",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 48,
+      "panels": [],
+      "title": "Workers",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots with multiple worker pools.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 23
+      },
+      "id": 37,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_worker_multiplepools_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with multiple Worker Pools",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots with multi zone worker pools.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 23
+      },
+      "id": 38,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_worker_multizones_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with multi zone Worker Pools",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots with worker pool taints.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 23
+      },
+      "id": 39,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_worker_taints_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoot with Worker Pools Taints",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots with worker pool labels.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 27
+      },
+      "id": 40,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_worker_labels_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoot with Worker Pools Labels",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots with worker pool annotations.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 27
+      },
+      "id": 41,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_worker_annotations_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoot with Worker Pool Annotations",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 52,
+      "panels": [],
+      "title": "kube-controller-manager",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which have node cidr mask size configured on the kube controller manager.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 32
+      },
+      "id": 34,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_kcm_nodecidrmasksize_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with Node CIDR Mask Size Configuration",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots with horizontal pod autoscaling for the kube controller manager.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 32
+      },
+      "id": 35,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_kcm_horizontalpodautoscale_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoot Kube Controller Manager with Horizontal Autoscaling",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "cluster-prometheus",
+      "decimals": 0,
+      "description": "Count of Shoots with enabled kube controller manager feature gates.",
+      "fill": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 36,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_kcm_featuregates_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{featuregate}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Shoot Kube Controller Manager with Feature Gates",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 50,
+      "panels": [],
+      "title": "Misc",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which have a pod pid limit configured for the kubelet(s).",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 37
+      },
+      "id": 24,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_kubelet_podpidlimit_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with Kubelet Pod PID Limit Configuration",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "cluster-prometheus",
+      "decimals": 0,
+      "description": "Count of Shoots with enabled kube scheduler feature gates.",
+      "fill": 0,
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 6,
+        "y": 37
+      },
+      "id": 42,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_scheduler_featuregates_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{admissionplugin}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Shoot Kube Schedulers with Feature Gates",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which have nginx ingress conroller addon enabled.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 41
+      },
+      "id": 26,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_addon_nginxingress_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with Nginx Ingress Addon",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(40, 40, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "cluster-prometheus",
+      "decimals": null,
+      "description": "Count of Shoots which have kubernetes dashboard addon enabled.",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 41
+      },
+      "id": 27,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "garden_shoots_custom_addon_kubedashboard_total",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "title": "Shoots with Kube-Dashboard Addon",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "",
+          "value": ""
+        }
+      ],
+      "valueName": "current"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [
+    "Shoot",
+    "Gardener"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-10m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "30s"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Shoot Customization",
+  "version": 0
+}

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/gardener/gardener v0.0.0-20190830053951-194cf8abb797/go.mod h1:UjyQiG
 github.com/gardener/gardener v0.0.0-20191004085047-5707d498b40c/go.mod h1:zvajWsteDY43oECil7ADr4NNp88CMltFEutUp1jX+zA=
 github.com/gardener/gardener v0.0.0-20191017105650-90c425422051 h1:7fZhgC6hYuX4ook05AbUGyYik1reZYmWFWiWYXdM0Vc=
 github.com/gardener/gardener v0.0.0-20191017105650-90c425422051/go.mod h1:EPowOY6iwWqit6mED3UOQv72bodT3YlYe/xnZHjvHWY=
+github.com/gardener/gardener v0.0.0-20191106070411-9c31920dd749 h1:U4xlS7jgXjYgS3cvKMHtjtEPH/50ldWIIgXONUr1YvE=
+github.com/gardener/gardener v0.0.0-20191107054722-54aec8c876f7 h1:q5FFMwd1PHxhBuOWe9YglqvPThHTPatyJ0Wm7SFLhJk=
 github.com/gardener/gardener-extensions v0.0.0-20190725050243-a80ef643c64b/go.mod h1:uXjtl3KeVdQXuGIP26+84wJY1Kwru67l0FXm7A5DiME=
 github.com/gardener/gardener-extensions v0.0.0-20190820050625-a15de8a82f6b/go.mod h1:q69+1cUGSfQ8gSMWzU7GFz/R8K8MpOLQBT2wJJcCjEA=
 github.com/gardener/gardener-extensions v0.0.0-20190906160200-5c329d46ae81/go.mod h1:OBUAbab8OMm8pvzr/1/cdwIQnQYuMoGDTNR2c+i9nYo=
@@ -365,6 +367,7 @@ github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod 
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0 h1:BQ53HtBmfOitExawJ6LokA4x8ov/z0SYYb0+HxJfRI8=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
+github.com/prometheus/client_golang v1.2.1 h1:JnMpQc6ppsNgw9QPAGF6Dod479itz7lvlsMzzNayLOI=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -83,6 +83,7 @@ func (c *gardenMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
 	for _, desc := range c.descs {
 		ch <- desc
 	}
+	registerShootCustomizationMetrics(ch)
 }
 
 // Collect implements the prometheus.Collect interface, which intends the gardenMetricsCollector to be a Prometheus collector.

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -64,6 +64,8 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 		return
 	}
 
+	collectShootCustomizationMetrics(shoots, ch)
+
 	for _, shoot := range shoots {
 		// Some Shoot sanity checks.
 		if shoot == nil || shoot.Spec.SeedName == nil {
@@ -100,6 +102,8 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 		// Collect metrics to the node count of the Shoot.
 		// TODO: Use the metrics of the Machine-Controller-Manager, when available. The mcm should be able to provide the actual amount of nodes/machines.
 		c.collectShootNodeMetrics(shoot, projectName, ch)
+
+		// collectShootCustomizationMetrics(shoot, projectName, ch)
 
 		if shoot.Status.LastOperation != nil {
 			lastOperation := string(shoot.Status.LastOperation.Type)

--- a/pkg/metrics/shoot_customization.go
+++ b/pkg/metrics/shoot_customization.go
@@ -1,0 +1,643 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/gardener/gardener-metrics-exporter/pkg/template"
+	"github.com/gardener/gardener-metrics-exporter/pkg/utils"
+	gardenv1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricShootsCustomPrefix = "garden_shoots_custom"
+	metricShootsPrefix       = "garden_shoots"
+)
+
+var shootCustomizationMetrics = []*template.MetricTemplate{
+	// General customization.
+	{
+		Name:   fmt.Sprintf("%s_privileged_containers_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which allow privileged containers.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.AllowPrivilegedContainers != nil && *s.Spec.Kubernetes.AllowPrivilegedContainers {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+
+	{
+		Name:   fmt.Sprintf("%s_extensions_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which have an extension(s) configured.",
+		Labels: []string{"extension"},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+
+			var extensionCounter = map[string]float64{}
+			for _, s := range shoots {
+				if s.Spec.Extensions != nil {
+					for _, extension := range s.Spec.Extensions {
+						extensionCounter[extension.Type]++
+					}
+				}
+			}
+			values, labels := mapLabelAndValues(&extensionCounter)
+			return values, labels, nil
+		},
+	},
+
+	// Kube API Server customization.
+	{
+		Name:   fmt.Sprintf("%s_apiserver_basicauth_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which have basic auth enabled on the kube apiserver.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.KubeAPIServer != nil && s.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication != nil && *s.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_apiserver_auditpolicy_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which have an audit log policy configured for the kube apiserver.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.KubeAPIServer != nil && s.Spec.Kubernetes.KubeAPIServer.AuditConfig != nil && s.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy != nil && s.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_apiserver_oidcconfig_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which have an open id connect coniguration for the kube apiserver.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.KubeAPIServer != nil && s.Spec.Kubernetes.KubeAPIServer.OIDCConfig != nil {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_apiserver_featuregates_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots with enabled kube apiserver feature gates.",
+		Labels: []string{"featuregate"},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+
+			var featureGateCounters = map[string]float64{}
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.KubeAPIServer != nil {
+					for featureGate, active := range s.Spec.Kubernetes.KubeAPIServer.FeatureGates {
+						if active {
+							featureGateCounters[featureGate]++
+						}
+					}
+				}
+			}
+			values, labels := mapLabelAndValues(&featureGateCounters)
+			return values, labels, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_apiserver_admissionplugins_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots with enabled kube apiserver admission plugins.",
+		Labels: []string{"admissionplugin"},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+
+			var admissionpluginCounters = map[string]float64{}
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.KubeAPIServer != nil {
+					for _, admissionPlugin := range s.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins {
+						admissionpluginCounters[admissionPlugin.Name]++
+					}
+				}
+			}
+			values, labels := mapLabelAndValues(&admissionpluginCounters)
+			return values, labels, nil
+		},
+	},
+
+	// Kube Controller Manager customization.
+	{
+		Name:   fmt.Sprintf("%s_kcm_nodecidrmasksize_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which have node cidr mask size configured on the kube controller manager.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.KubeControllerManager != nil && s.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize != nil {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_kcm_horizontalpodautoscale_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots with horizontal pod autoscaling for the kube controller manager.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.KubeControllerManager != nil && s.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig != nil {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_kcm_featuregates_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots with enabled kube controller manager feature gates.",
+		Labels: []string{"featuregate"},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+
+			var featureGateCounters = map[string]float64{}
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.KubeControllerManager != nil {
+					for featureGate, active := range s.Spec.Kubernetes.KubeControllerManager.FeatureGates {
+						if active {
+							featureGateCounters[featureGate]++
+						}
+					}
+				}
+			}
+			var (
+				timeSeriesCount = len(featureGateCounters)
+				values          = make([]float64, 0, timeSeriesCount)
+				labelSets       = make([][]string, 0, timeSeriesCount)
+			)
+			for i, k := range featureGateCounters {
+				labelSets = append(labelSets, []string{i})
+				values = append(values, k)
+			}
+			return &values, &labelSets, nil
+		},
+	},
+
+	// Kube Scheduler customization.
+	{
+		Name:   fmt.Sprintf("%s_scheduler_featuregates_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots with enabled kube scheduler feature gates.",
+		Labels: []string{"featuregate"},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+
+			var featureGateCounters = map[string]float64{}
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.KubeScheduler != nil {
+					for featureGate, active := range s.Spec.Kubernetes.KubeScheduler.FeatureGates {
+						if active {
+							featureGateCounters[featureGate]++
+						}
+					}
+				}
+			}
+			values, labels := mapLabelAndValues(&featureGateCounters)
+			return values, labels, nil
+		},
+	},
+
+	// Kubelet customization.
+	{
+		Name:   fmt.Sprintf("%s_kubelet_podpidlimit_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which have a pod pid limit configured for the kubelet(s).",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.Kubelet != nil && s.Spec.Kubernetes.Kubelet.PodPIDsLimit != nil {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+
+	// Kube Proxy customization.
+	{
+		Name:   fmt.Sprintf("%s_proxy_mode_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which by proxy mode configuration for the kube proxy.",
+		Labels: []string{"mode"},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+
+			var modeCounters = map[string]float64{}
+			for _, s := range shoots {
+				if s.Spec.Kubernetes.KubeProxy != nil && s.Spec.Kubernetes.KubeProxy.Mode != nil {
+					modeCounters[string(*s.Spec.Kubernetes.KubeProxy.Mode)]++
+				} else {
+					modeCounters[unknown]++
+				}
+			}
+			var (
+				timeSeriesCount = len(modeCounters)
+				values          = make([]float64, 0, timeSeriesCount)
+				labelSets       = make([][]string, 0, timeSeriesCount)
+			)
+			for i, k := range modeCounters {
+				labelSets = append(labelSets, []string{i})
+				values = append(values, k)
+			}
+			return &values, &labelSets, nil
+		},
+	},
+
+	// Worker pool customization.
+	{
+		Name:   fmt.Sprintf("%s_worker_multiplepools_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots with multiple worker pools.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if len(s.Spec.Provider.Workers) > 1 {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_worker_multizones_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots with multi zone worker pools.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				for _, w := range s.Spec.Provider.Workers {
+					if len(w.Zones) > 1 {
+						counter[0]++
+						break
+					}
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_worker_taints_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots with worker pool taints.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				for _, w := range s.Spec.Provider.Workers {
+					if len(w.Taints) > 0 {
+						counter[0]++
+						break
+					}
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_worker_labels_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots with worker pool labels.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				for _, w := range s.Spec.Provider.Workers {
+					if len(w.Labels) > 0 {
+						counter[0]++
+						break
+					}
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_worker_annotations_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots with worker pool annotations.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				for _, w := range s.Spec.Provider.Workers {
+					if len(w.Annotations) > 0 {
+						counter[0]++
+						break
+					}
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+
+	// Network customization.
+	{
+		Name:   fmt.Sprintf("%s_network_customdomain_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which use a custom dns domain.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.DNS != nil && len(s.Spec.DNS.Providers) > 0 {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+
+	// Addons customization.
+	{
+		Name:   fmt.Sprintf("%s_addon_nginxingress_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which have nginx ingress conroller addon enabled.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Addons != nil && s.Spec.Addons.NginxIngress != nil && s.Spec.Addons.NginxIngress.Enabled {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_addon_kubedashboard_total", metricShootsCustomPrefix),
+		Help:   "Count of Shoots which have kubernetes dashboard addon enabled.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Addons != nil && s.Spec.Addons.KubernetesDashboard != nil && s.Spec.Addons.KubernetesDashboard.Enabled {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+
+	// TODO: Hibernation/Maintenance configurations shouldn't be treated as Shoot customization.
+	// Therefore the metrics should move perspectively to another location.
+	// Hibernation.
+	{
+		Name:   fmt.Sprintf("%s_hibernation_enabled_total", metricShootsPrefix),
+		Help:   "Count of Shoots which have hibernation enabled.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Hibernation != nil && s.Spec.Hibernation.Enabled != nil && *s.Spec.Hibernation.Enabled {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_hibernation_schedule_total", metricShootsPrefix),
+		Help:   "Count of Shoots which have a hibernation schedule configured.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Hibernation != nil && len(s.Spec.Hibernation.Schedules) > 0 {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+
+	// Maintenance.
+	{
+		Name:   fmt.Sprintf("%s_maintenance_window_total", metricShootsPrefix),
+		Help:   "Count of Shoots which have a maintenance window configured.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Maintenance != nil && s.Spec.Maintenance.TimeWindow != nil {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_maintenance_autoupdate_k8sversion_total", metricShootsPrefix),
+		Help:   "Count of Shoots which have autoupdate for kubernetes versions configured.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Maintenance != nil && s.Spec.Maintenance.AutoUpdate != nil && s.Spec.Maintenance.AutoUpdate.KubernetesVersion {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+	{
+		Name:   fmt.Sprintf("%s_maintenance_autoupdate_imageversion_total", metricShootsPrefix),
+		Help:   "Count of Shoots which have autoupdate for machine image versions configured.",
+		Labels: []string{},
+		Type:   template.Gauge,
+		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
+			shoots, ok := obj.([]*gardenv1alpha1.Shoot)
+			if !ok {
+				return nil, nil, utils.NewTypeConversionError()
+			}
+			var counter = make([]float64, 1, 1)
+			for _, s := range shoots {
+				if s.Spec.Maintenance != nil && s.Spec.Maintenance.AutoUpdate != nil && s.Spec.Maintenance.AutoUpdate.MachineImageVersion {
+					counter[0]++
+				}
+			}
+			return &counter, &[][]string{}, nil
+		},
+	},
+}
+
+func registerShootCustomizationMetrics(ch chan<- *prometheus.Desc) {
+	for _, c := range shootCustomizationMetrics {
+		c.Register(ch)
+	}
+}
+
+func collectShootCustomizationMetrics(shoots []*gardenv1alpha1.Shoot, ch chan<- prometheus.Metric) {
+	var (
+		wg  sync.WaitGroup
+		run = func(c *template.MetricTemplate) {
+			c.Collect(ch, shoots)
+			wg.Done()
+		}
+	)
+	wg.Add(len(shootCustomizationMetrics))
+	for _, c := range shootCustomizationMetrics {
+		go run(c)
+	}
+	wg.Wait()
+}
+
+func mapLabelAndValues(list *map[string]float64) (*[]float64, *[][]string) {
+	var (
+		timeSeriesCount = len(*list)
+		values          = make([]float64, 0, timeSeriesCount)
+		labelSets       = make([][]string, 0, timeSeriesCount)
+	)
+	for i, k := range *list {
+		labelSets = append(labelSets, []string{i})
+		values = append(values, k)
+	}
+	return &values, &labelSets
+}

--- a/pkg/metrics/utils.go
+++ b/pkg/metrics/utils.go
@@ -23,6 +23,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const unknown = "unknown"
+
 var (
 	// ScrapeFailures is a metric, which counts the amount scrape issues grouped by kind.
 	ScrapeFailures = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+// Type define a metric type for a Prometheus metric.
+type Type string
+
+var (
+	// Gauge is a type which refers to Prometheus Gauge value.
+	Gauge Type = "gauge"
+
+	// Counter is a type which refers to Prometheus Counter value.
+	Counter Type = "counter"
+)
+
+// MetricTemplate define a template for metrics of same kind. It holds all necessary
+// information about the metric and instructions how to collect metric samples.
+type MetricTemplate struct {
+	Name        string
+	Help        string
+	Labels      []string
+	Type        Type
+	desc        *prometheus.Desc
+	CollectFunc func(interface{}, ...interface{}) (*[]float64, *[][]string, error)
+}
+
+// Register registers the MetricTemplate to the Prometheus Gatherer to allow
+// the collection of metric samples which are created based on the template.
+func (m *MetricTemplate) Register(ch chan<- *prometheus.Desc) {
+	m.desc = prometheus.NewDesc(m.Name, m.Help, m.Labels, nil)
+	ch <- m.desc
+}
+
+// Collect triggers the collection of metric samples which are created based on
+// template by executing the internal CollectFunc.
+func (m *MetricTemplate) Collect(ch chan<- prometheus.Metric, obj interface{}, parameters ...interface{}) {
+	values, labelValues, err := m.CollectFunc(obj, parameters...)
+	if err != nil {
+		log.Error(err.Error())
+		return
+	}
+
+	var (
+		vals     = *values
+		labels   = *labelValues
+		noLabels = len(labels) == 0
+	)
+
+	if !noLabels && len(vals) != len(labels) {
+		log.Error("Amount of values does not fit with amount of labelsets")
+		return
+	}
+
+	for i := range vals {
+		var metric prometheus.Metric
+		if noLabels {
+			metric, err = prometheus.NewConstMetric(m.desc, mapType(m.Type), vals[i])
+		} else {
+			metric, err = prometheus.NewConstMetric(m.desc, mapType(m.Type), vals[i], labels[i]...)
+		}
+
+		if err != nil {
+			log.Error(err.Error())
+			return
+		}
+		ch <- metric
+	}
+}
+
+func mapType(t Type) prometheus.ValueType {
+	switch t {
+	case Gauge:
+		return prometheus.GaugeValue
+	case Counter:
+		return prometheus.CounterValue
+	default:
+		return prometheus.UntypedValue
+	}
+}

--- a/pkg/utils/errors.go
+++ b/pkg/utils/errors.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "errors"
+
+const typeConversionError = "Type conversion error"
+
+// NewTypeConversionError returns an error for a failed type conversion situation.
+func NewTypeConversionError() error {
+	return errors.New(typeConversionError)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduce some first metrics for Shoot cluster customisations.
Beside that it introduce a metric template approach which allow to describe metrics in a more declarative way.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Gardener metrics exporter now exposes metrics about Shoot cluster customisations.
```

cc @dguendisch 