### PR TITLE
Add creation timestamp metric for shoots

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -35,6 +35,7 @@ const (
 	// Shoot metric (available also for Shoots which act as Seed).
 	metricGardenShootInfo                     = "garden_shoot_info"
 	metricGardenShootCondition                = "garden_shoot_condition"
+	metricGardenShootCreation                 = "garden_shoot_creation_timestamp"
 	metricGardenShootOperationState           = "garden_shoot_operation_states"
 	metricGardenShootOperationProgressPercent = "garden_shoot_operation_progress_percent"
 	metricGardenShootNodeMaxTotal             = "garden_shoot_node_max_total"
@@ -49,6 +50,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 	return map[string]*prometheus.Desc{
 		metricGardenSeedCondition: prometheus.NewDesc(metricGardenSeedCondition, "Condition state of a Seed.", []string{"name", "condition"}, nil),
 		metricGardenSeedInfo:      prometheus.NewDesc(metricGardenSeedInfo, "Information about a Seed.", []string{"name", "namespace", "iaas", "region", "visible", "protected"}, nil),
+		metricGardenShootCreation: prometheus.NewDesc(metricGardenShootCreation, "Timestamp of the shoot creation.", []string{"name", "project", "uid"}, nil),
 
 		metricGardenProjectsStatus: prometheus.NewDesc(metricGardenProjectsStatus, "Status of projects.", []string{"name", "cluster", "phase"}, nil),
 		metricGardenUsersSum:       prometheus.NewDesc(metricGardenUsersSum, "Count of users.", []string{"kind"}, nil),

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -99,6 +99,11 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 		}
 		ch <- metric
 
+		shootCreation := shoot.CreationTimestamp
+		metric, err = prometheus.NewConstMetric(c.descs[metricGardenShootCreation], prometheus.GaugeValue, float64(shootCreation.Unix()), shoot.Name, *projectName, string(shoot.UID))
+
+		ch <- metric
+
 		// Collect metrics to the node count of the Shoot.
 		// TODO: Use the metrics of the Machine-Controller-Manager, when available. The mcm should be able to provide the actual amount of nodes/machines.
 		c.collectShootNodeMetrics(shoot, projectName, ch)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a metric that saves the creation timestamp of a shoot. Can be used to calculate how long a shoot has existed.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Added metric `garden_shoot_creation_timestamp`.
```