### PR TITLE
Add kubeconfig placeholder

### DIFF
--- a/charts/gardener-metrics-exporter/values.yaml
+++ b/charts/gardener-metrics-exporter/values.yaml
@@ -4,3 +4,4 @@ server:
 image:
   repository: eu.gcr.io/gardener-project/gardener/metrics-exporter
   tag: latest
+# kubeconfig: ...

--- a/charts/gardener-metrics-exporter/values.yaml
+++ b/charts/gardener-metrics-exporter/values.yaml
@@ -4,4 +4,4 @@ server:
 image:
   repository: eu.gcr.io/gardener-project/gardener/metrics-exporter
   tag: latest
-# kubeconfig: ...
+# kubeconfig: a3ViZWNvbmZpZwo=


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds kubeconfig placeholder to `values.yaml` in order to highlight that a kubeconfig has to be provided.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
As discussed with @wyb1 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```