### PR TITLE
Add garden_shoot_node_info metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -45,6 +45,7 @@ const (
 
 	// Aggregated Shoot metrics (exclude Shoots which act as Seed).
 	metricGardenOperationsTotal = "garden_shoot_operations_total"
+	metricGardenShootNodeInfo   = "garden_shoot_node_info"
 )
 
 func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
@@ -72,6 +73,8 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 		metricGardenShootNodeMaxTotal: prometheus.NewDesc(metricGardenShootNodeMaxTotal, "Max node count of a Shoot.", []string{"name", "project"}, nil),
 
 		metricGardenShootNodeMinTotal: prometheus.NewDesc(metricGardenShootNodeMinTotal, "Min node count of a Shoot.", []string{"name", "project"}, nil),
+
+		metricGardenShootNodeInfo: prometheus.NewDesc(metricGardenShootNodeInfo, "Information about the nodes in a Shoot.", []string{"name", "project", "worker_group", "image", "version"}, nil),
 
 		metricGardenShootOperationProgressPercent: prometheus.NewDesc(metricGardenShootOperationProgressPercent, "Operation progress percent of a Shoot.", []string{"name", "project", "operation"}, nil),
 

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -196,6 +196,14 @@ func (c gardenMetricsCollector) collectShootNodeMetrics(shoot *gardenv1beta1.Sho
 	for _, worker := range workers {
 		nodeCountMax += worker.Minimum
 		nodeCountMin += worker.Maximum
+
+		// Expose metrics about the Shoot's nodes.
+		metric, err := prometheus.NewConstMetric(c.descs[metricGardenShootNodeInfo], prometheus.GaugeValue, 0, shoot.Name, *projectName, worker.Name, worker.Machine.Image.Name, *worker.Machine.Image.Version)
+		if err != nil {
+			ScrapeFailures.With(prometheus.Labels{"kind": "shoots"}).Inc()
+			return
+		}
+		ch <- metric
 	}
 
 	// Expose metrics. Start with max node count.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new metric `garden_shoot_node_info` that is similar to the metric `garden_shoot_info`. This metric is useful for finding out which images are used in seeds and in which versions.

**Which issue(s) this PR fixes**:
Fixes #32 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add a new metric `garden_shoot_node_info` to keep track of operating system images and versions in a gardener landscape
```