### PR TITLE
Remove metric `garden_shoot_response_duration_milliseconds`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The `gardener-metrics-exporter` is a [Prometheus](https://prometheus.io/) metric
 |garden_shoot_operations_total|Count of ongoing operations|Shoot|Gauge|
 |garden_shoot_operation_states|Operation State of a Shoot|Shoot|Gauge|
 |garden_shoot_operation_progress_percent|Operation Percentage of a Shoot|Shoot|Gauge|
-|garden_shoot_response_duration_milliseconds| Response time of the Shoot API server (Not provided when not reachable)|Shoot|Gauge|
 |garden_seed_info|Information to a Seed|Seed|Gauge|
 |garden_seed_condition|Condition State of a Seed|Seed|Gauge|
 |garden_projects_status|Status of Garden Projects|Projects|Gauge|

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -41,7 +41,6 @@ const (
 	metricGardenShootNodeMinTotal             = "garden_shoot_node_min_total"
 	metricGardenShootOperationProgressPercent = "garden_shoot_operation_progress_percent"
 	metricGardenShootOperationState           = "garden_shoot_operation_states"
-	metricGardenShootResponseDuration         = "garden_shoot_response_duration_milliseconds"
 
 	// Aggregated Shoot metrics (exclude Shoots which act as Seed).
 	metricGardenOperationsTotal = "garden_shoot_operations_total"
@@ -79,8 +78,6 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 		metricGardenShootOperationProgressPercent: prometheus.NewDesc(metricGardenShootOperationProgressPercent, "Operation progress percent of a Shoot.", []string{"name", "project", "operation"}, nil),
 
 		metricGardenShootOperationState: prometheus.NewDesc(metricGardenShootOperationState, "Operation state of a Shoot.", []string{"name", "project", "operation"}, nil),
-
-		metricGardenShootResponseDuration: prometheus.NewDesc(metricGardenShootResponseDuration, "Response time of the Shoot API server. Not provided when not reachable.", []string{"name", "project"}, nil),
 
 		metricGardenUsersSum: prometheus.NewDesc(metricGardenUsersSum, "Count of users.", []string{"kind"}, nil),
 	}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -34,7 +34,7 @@ var (
 
 const (
 	metricShootsCustomPrefix = "garden_shoots_custom"
-	metricShootsPrefix = "garden_shoots"
+	metricShootsPrefix       = "garden_shoots"
 )
 
 // MetricTemplate define a template for metrics of same kind. It holds all necessary
@@ -87,7 +87,7 @@ func (m *MetricTemplate) Collect(ch chan<- prometheus.Metric, obj interface{}, p
 			log.Error(err.Error())
 			return
 		}
-			ch <- metric
+		ch <- metric
 	}
 
 	// build and send merged metric for customization metrics
@@ -136,7 +136,7 @@ func (m *MetricTemplate) sendMergedMetric(vals []float64, labels [][]string, ch 
 				log.Error(err.Error())
 				continue
 			}
-			ch <-  m
+			ch <- m
 		}
 	}
 	return


### PR DESCRIPTION
**What this PR does / why we need it**:
Metric no longer exists due to a change in gardener

**Which issue(s) this PR fixes**:
Fixes #36 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```action operator
Remove metric `garden_shoot_response_duration_milliseconds`
```