### PR TITLE
Format Readme according to remark-lint and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,66 @@
 # Gardener Metrics Exporter
-The `gardener-metrics-exporter` is a [Prometheus](https://prometheus.io/) metrics exporter for [Gardener](https://github.com/gardener/gardener) service-level related metrics.
+
+The `gardener-metrics-exporter` is a [Prometheus](https://prometheus.io/)
+metrics exporter for [Gardener](https://github.com/gardener/gardener)
+service-level related metrics.
 
 **This application requires Go 1.9 or later.**
 
 ## Metrics
-|Metric|Description|Scope|Type|
-|-----|-----------|-----|----|
-|garden_shoot_operation_states|Operation state of a Shoot|Shoot|Gauge|
-|garden_shoot_info|Information to a Shoot|Shoot|Gauge|
-|garden_shoot_condition|Condition state of a Shoot|Shoot|Gauge|
-|garden_shoot_node_min_total|Min node count of a Shoot|Shoot|Gauge|
-|garden_shoot_node_max_total|Max node count of a Shoot|Shoot|Gauge|
-|garden_shoot_operations_total|Count of ongoing operations|Shoot|Gauge|
-|garden_shoot_operation_states|Operation State of a Shoot|Shoot|Gauge|
-|garden_shoot_operation_progress_percent|Operation Percentage of a Shoot|Shoot|Gauge|
-|garden_seed_info|Information to a Seed|Seed|Gauge|
-|garden_seed_condition|Condition State of a Seed|Seed|Gauge|
-|garden_projects_status|Status of Garden Projects|Projects|Gauge|
-|garden_users_total|Count of users|Users|Gauge|
-|garden_scrape_failure_total|Total count of scraping failures, grouped by kind/group of metric(s)|App|Counter|
+
+| Metric                                  | Description                                                          | Scope    | Type    |
+|:----------------------------------------|:---------------------------------------------------------------------|:---------|:--------|
+| garden_shoot_operation_states           | Operation state of a Shoot                                           | Shoot    | Gauge   |
+| garden_shoot_info                       | Information to a Shoot                                               | Shoot    | Gauge   |
+| garden_shoot_condition                  | Condition state of a Shoot                                           | Shoot    | Gauge   |
+| garden_shoot_node_min_total             | Min node count of a Shoot                                            | Shoot    | Gauge   |
+| garden_shoot_node_max_total             | Max node count of a Shoot                                            | Shoot    | Gauge   |
+| garden_shoot_operations_total           | Count of ongoing operations                                          | Shoot    | Gauge   |
+| garden_shoot_operation_states           | Operation State of a Shoot                                           | Shoot    | Gauge   |
+| garden_shoot_operation_progress_percent | Operation Percentage of a Shoot                                      | Shoot    | Gauge   |
+| garden_seed_info                        | Information to a Seed                                                | Seed     | Gauge   |
+| garden_seed_condition                   | Condition State of a Seed                                            | Seed     | Gauge   |
+| garden_projects_status                  | Status of Garden Projects                                            | Projects | Gauge   |
+| garden_users_total                      | Count of users                                                       | Users    | Gauge   |
+| garden_scrape_failure_total             | Total count of scraping failures, grouped by kind/group of metric(s) | App      | Counter |
 
 ## Grafana Dashboards
-Some [Grafana](https://grafana.com/) dashboards are included in the `dashboards` folder. Simply import them and make sure you have your Prometheus data source named to `cluster-prometheus`.
+
+Some [Grafana](https://grafana.com/) dashboards are included in the `dashboards`
+folder. Simply import them and make sure you have your Prometheus data source
+named to `cluster-prometheus`.
 
 ## Usage
+
 First, clone the repo into your `$GOPATH`.
+
 ```sh
 mkdir -p "$GOPATH/src/github.com/gardener"
-git clone https://github.com/gardener/gardener-metrics-exporter.git "$GOPATH/src/github.com/gardener/gardener-metrics-exporter"
+git clone https://github.com/gardener/gardener-metrics-exporter.git \
+          "$GOPATH/src/github.com/gardener/gardener-metrics-exporter"
 
 cd "$GOPATH/src/github.com/gardener/gardener-metrics-exporter"
 ```
 
 ### Local
-The metrics exporter needs to run against a Gardener enviroment (Kubernetes cluster extendend with `core.gardener.cloud/v1alpha1` api group). Such an enviroment can be created by following the instructions here: https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md
 
-If the current-context of your `$HOME/.kube/config` point to a Gardener enviroment then you can simply run:
+The metrics exporter needs to run against a Gardener enviroment (Kubernetes
+cluster extendend with `core.gardener.cloud/v1alpha1` api group). Such an
+enviroment can be created by following the instructions here:
+https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md
+
+If the current-context of your `$HOME/.kube/config` point to a Gardener
+enviroment then you can simply run:
+
 ```sh
 make start
 ```
 
-If you plan to pass a specific kubeconfig then you need to build the app locally and pass a kubeconfig to the binary.
-Let's build the app for your enviroment locally and run it. The binary will be located in the `./bin` directory of the repository.
+If you plan to pass a specific kubeconfig then you need to build the app locally
+and pass a kubeconfig to the binary. Let's build the app for your enviroment
+locally and run it. The binary will be located in the `./bin` directory of the
+repository.
+
 ```sh
 # Build
 make build-local
@@ -50,13 +69,19 @@ make build-local
 ./bin/gardener-metrics-exporter --kubeconfig=<path-to-kubeconfig-file>
 ```
 
-**Be aware:** The user in the kubeconfig needs permissions to ``GET, LIST, WATCH`` the resources ``Shoot, Seed, Project, Plant (core.gardener.cloud/v1alpha1)`` in all namespaces of the cluster.
+**Be aware:** The user in the kubeconfig needs permissions to ``GET, LIST,
+*WATCH`` the resources ``Shoot, Seed, Project, Plant
+*(core.gardener.cloud/v1alpha1)`` in all namespaces of the cluster.
 
 Verify that everything works by calling the `/metrics` endpoint of the app.
+
 ```sh
 curl http://localhost:2718/metrics
 ```
-Run a local [Prometheus](https://prometheus.io/download/) instance and add the following scrape config snippet to your config.
+
+Run a local [Prometheus](https://prometheus.io/download/) instance and add the
+following scrape config snippet to your config.
+
 ```yaml
 scrape_configs:
 - job_name: 'gardener-metrics-exporter'
@@ -68,14 +93,21 @@ scrape_configs:
      regex: '^garden_.*$'
      action: keep
 ```
-Now the metrics should be collected by Prometheus. Open the Prometheus console and query for ``garden_*`` metrics.
+
+Now the metrics should be collected by Prometheus. Open the Prometheus console
+and query for ``garden_*`` metrics.
 
 ### In Cluster
+
 Deploy the metrics-exporter to a kubernetes cluster via helm.
+
 ```sh
-helm upgrade gardener-metrics-exporter charts/gardener-metrics-exporter --install --namespace=<your-namespace> --values=<path-to-your-values.yaml>
+helm upgrade gardener-metrics-exporter charts/gardener-metrics-exporter \
+     --install --namespace=<your-namespace> --values=<path-to-your-values.yaml>
 ```
+
 For example, the scrape config for your Prometheus could look like this:
+
 ```yaml
 scrape_configs:
 - job_name: 'gardener-metrics-exporter'

--- a/README.md
+++ b/README.md
@@ -43,20 +43,20 @@ cd "$GOPATH/src/github.com/gardener/gardener-metrics-exporter"
 
 ### Local
 
-The metrics exporter needs to run against a Gardener enviroment (Kubernetes
+The metrics exporter needs to run against a Gardener environment (Kubernetes
 cluster extendend with `core.gardener.cloud/v1alpha1` api group). Such an
-enviroment can be created by following the instructions the [gardener local
+environment can be created by following the instructions the [gardener local
 setup][].
 
 If the current-context of your `$HOME/.kube/config` point to a Gardener
-enviroment then you can simply run:
+environment then you can simply run:
 
 ```sh
 make start
 ```
 
 If you plan to pass a specific kubeconfig then you need to build the app locally
-and pass a kubeconfig to the binary. Let's build the app for your enviroment
+and pass a kubeconfig to the binary. Let's build the app for your environment
 locally and run it. The binary will be located in the `./bin` directory of the
 repository.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Gardener Metrics Exporter
 
-The `gardener-metrics-exporter` is a [Prometheus](https://prometheus.io/)
-metrics exporter for [Gardener](https://github.com/gardener/gardener)
-service-level related metrics.
+The `gardener-metrics-exporter` is a [Prometheus][] metrics exporter for
+[Gardener][] service-level related metrics.
 
 **This application requires Go 1.9 or later.**
 
@@ -26,9 +25,9 @@ service-level related metrics.
 
 ## Grafana Dashboards
 
-Some [Grafana](https://grafana.com/) dashboards are included in the `dashboards`
-folder. Simply import them and make sure you have your Prometheus data source
-named to `cluster-prometheus`.
+Some [Grafana][] dashboards are included in the `dashboards` folder. Simply
+import them and make sure you have your Prometheus data source named to
+`cluster-prometheus`.
 
 ## Usage
 
@@ -46,8 +45,8 @@ cd "$GOPATH/src/github.com/gardener/gardener-metrics-exporter"
 
 The metrics exporter needs to run against a Gardener enviroment (Kubernetes
 cluster extendend with `core.gardener.cloud/v1alpha1` api group). Such an
-enviroment can be created by following the instructions here:
-https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md
+enviroment can be created by following the instructions the [gardener local
+setup][].
 
 If the current-context of your `$HOME/.kube/config` point to a Gardener
 enviroment then you can simply run:
@@ -79,8 +78,8 @@ Verify that everything works by calling the `/metrics` endpoint of the app.
 curl http://localhost:2718/metrics
 ```
 
-Run a local [Prometheus](https://prometheus.io/download/) instance and add the
-following scrape config snippet to your config.
+Run a local [Prometheus][] instance and add the following scrape config snippet
+to your config.
 
 ```yaml
 scrape_configs:
@@ -125,3 +124,8 @@ scrape_configs:
      regex: '^garden_.*$'
      action: keep
 ```
+
+[grafana]: https://grafana.com/
+[prometheus]: https://prometheus.io/
+[gardener]: https://github.com/gardener/gardener
+[gardener local setup]: https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md


### PR DESCRIPTION
**What this PR does / why we need it**:

It formats the readme according to the hints of https://github.com/remarkjs/remark-lint and fixes a typo.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```