### PR TITLE
Enrich shoot metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,3 @@
 
 bin
 dev
-tmp
-
-gardener-metrics-exporter
-metrics-exporter
-TODO

--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,14 @@ start:
 
 .PHONY: build
 build:
-	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
-		-mod=vendor \
+	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
 		-o $(WORKDIR)/bin/gardener-metrics-exporter \
 		-ldflags $(LDFLAGS) \
 		$(WORKDIR)/cmd/main.go
 
 .PHONY: build-local
 build-local:
-	@GO111MODULE=on go build -i \
-		-mod=vendor \
+	@go build -i \
 		-o $(WORKDIR)/bin/gardener-metrics-exporter \
 		-ldflags $(LDFLAGS) \
 		$(WORKDIR)/cmd/main.go
@@ -52,15 +50,6 @@ docker-push: docker-build
 	@echo "Push image to registry ..."
 	@gcloud docker -- push $(IMAGE_REPOSITORY):$(IMAGE_TAG)
 	@gcloud docker -- push $(IMAGE_REPOSITORY):latest
-
-.PHONY: revendor
-revendor:
-	@GO111MODULE=on go mod vendor
-	@GO111MODULE=on go mod tidy
-	# The machine-controller-manager repository references different version of the k8s.io packages which results in
-	# vendoring issues. To circumvent them and to avoid the necessity of copying their content into our repository we
-	# delete troubling files here (in fact, we are only requiring the types.go file).
-	@rm -f vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
 
 .PHONY: clean
 clean:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -61,13 +61,13 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 
 		metricGardenSeedInfo: prometheus.NewDesc(metricGardenSeedInfo, "Information about a Seed.", []string{"name", "namespace", "iaas", "region", "visible", "protected"}, nil),
 
-		metricGardenShootCondition: prometheus.NewDesc(metricGardenShootCondition, "Condition state of a Shoot. Possible values: -1=Unknown|0=Unhealthy|1=Healthy|2=Progressing", []string{"name", "project", "condition", "operation", "purpose", "is_seed", "iaas"}, nil),
+		metricGardenShootCondition: prometheus.NewDesc(metricGardenShootCondition, "Condition state of a Shoot. Possible values: -1=Unknown|0=Unhealthy|1=Healthy|2=Progressing", []string{"name", "project", "condition", "operation", "purpose", "is_seed", "iaas", "seed_iaas", "seed_region"}, nil),
 
 		metricGardenShootCreation: prometheus.NewDesc(metricGardenShootCreation, "Timestamp of the shoot creation.", []string{"name", "project", "uid"}, nil),
 
 		metricGardenShootHibernated: prometheus.NewDesc(metricGardenShootHibernated, "Hibernation status of a shoot.", []string{"name", "project", "uid"}, nil),
 
-		metricGardenShootInfo: prometheus.NewDesc(metricGardenShootInfo, "Information about a Shoot.", []string{"name", "project", "iaas", "version", "region", "seed", "is_seed"}, nil),
+		metricGardenShootInfo: prometheus.NewDesc(metricGardenShootInfo, "Information about a Shoot.", []string{"name", "project", "iaas", "version", "region", "seed", "is_seed", "seed_iaas", "seed_region"}, nil),
 
 		metricGardenShootNodeMaxTotal: prometheus.NewDesc(metricGardenShootNodeMaxTotal, "Max node count of a Shoot.", []string{"name", "project"}, nil),
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The metrics `garden_shoot_info` and `garden_shoot_condition` now have the labels `seed_iaas` and `seed_region` which describe the infrastructure and region of the seed, respectively.

**Which issue(s) this PR fixes**:

Fixes #38

**Special notes for your reviewer**:

Updated the `Makefile` with some leftovers from #41
Cleaned up gitignore file

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
The metric `garden_shoot_info` now has the labels `seed_iaas` and `seed_region` which describe the infrastructure and region of the seed, respectively.
```
```noteworthy operator
The metric `garden_shoot_condition` now has the labels `seed_iaas` and `seed_region` which describe the infrastructure and region of the seed, respectively.
```