### PR TITLE
Add uid label to garden_shoot_condition metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -108,6 +108,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"iaas",
 				"seed_iaas",
 				"seed_region",
+				"uid",
 			},
 			nil,
 		),

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -74,8 +74,8 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 		}
 
 		var (
-			isSeed  bool
-			purpose string
+			isSeed       bool
+			purpose, uid string
 
 			iaas = shoot.Spec.Provider.Type
 			seed = *shoot.Spec.SeedName
@@ -122,10 +122,12 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 			hibernatedVal = 1
 		}
 
+		uid = string(shoot.UID)
+
 		labels := []string{
 			shoot.Name,
 			*projectName,
-			string(shoot.UID),
+			uid,
 		}
 
 		metric, err = prometheus.NewConstMetric(
@@ -225,6 +227,7 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 						iaas,
 						seeds[*shoot.Spec.SeedName].Spec.Provider.Type,
 						seeds[*shoot.Spec.SeedName].Spec.Provider.Region,
+						uid,
 					}...,
 				)
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `uid` label to the `garden_shoot_condition` metric.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add label `uid` to `garden_shoot_condition` metric. The `uid` corresponds to the `uid` of the shoot object.
```