### PR TITLE
Add seed capacity metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,22 @@ The `gardener-metrics-exporter` is a [Prometheus][] metrics exporter for
 
 ## Metrics
 
-| Metric                                  | Description                                                          | Scope    | Type    |
-|:----------------------------------------|:---------------------------------------------------------------------|:---------|:--------|
-| garden_shoot_operation_states           | Operation state of a Shoot                                           | Shoot    | Gauge   |
-| garden_shoot_info                       | Information to a Shoot                                               | Shoot    | Gauge   |
-| garden_shoot_condition                  | Condition state of a Shoot                                           | Shoot    | Gauge   |
-| garden_shoot_node_min_total             | Min node count of a Shoot                                            | Shoot    | Gauge   |
-| garden_shoot_node_max_total             | Max node count of a Shoot                                            | Shoot    | Gauge   |
-| garden_shoot_operations_total           | Count of ongoing operations                                          | Shoot    | Gauge   |
-| garden_shoot_operation_states           | Operation State of a Shoot                                           | Shoot    | Gauge   |
-| garden_shoot_operation_progress_percent | Operation Percentage of a Shoot                                      | Shoot    | Gauge   |
-| garden_seed_info                        | Information to a Seed                                                | Seed     | Gauge   |
-| garden_seed_condition                   | Condition State of a Seed                                            | Seed     | Gauge   |
-| garden_projects_status                  | Status of Garden Projects                                            | Projects | Gauge   |
-| garden_users_total                      | Count of users                                                       | Users    | Gauge   |
-| garden_scrape_failure_total             | Total count of scraping failures, grouped by kind/group of metric(s) | App      | Counter |
+| Metric                                  | Description                                                               | Scope    | Type    |
+|:----------------------------------------|:--------------------------------------------------------------------------|:---------|:--------|
+| garden_shoot_operation_states           | Operation state of a Shoot                                                | Shoot    | Gauge   |
+| garden_shoot_info                       | Information to a Shoot                                                    | Shoot    | Gauge   |
+| garden_shoot_condition                  | Condition state of a Shoot                                                | Shoot    | Gauge   |
+| garden_shoot_node_min_total             | Min node count of a Shoot                                                 | Shoot    | Gauge   |
+| garden_shoot_node_max_total             | Max node count of a Shoot                                                 | Shoot    | Gauge   |
+| garden_shoot_operations_total           | Count of ongoing operations                                               | Shoot    | Gauge   |
+| garden_shoot_operation_states           | Operation State of a Shoot                                                | Shoot    | Gauge   |
+| garden_shoot_operation_progress_percent | Operation Percentage of a Shoot                                           | Shoot    | Gauge   |
+| garden_seed_info                        | Information to a Seed                                                     | Seed     | Gauge   |
+| garden_seed_capacity                    | Information regarding a seed's capacity with respect to certain resources | Seed     | Gauge   |
+| garden_seed_condition                   | Condition State of a Seed                                                 | Seed     | Gauge   |
+| garden_projects_status                  | Status of Garden Projects                                                 | Projects | Gauge   |
+| garden_users_total                      | Count of users                                                            | Users    | Gauge   |
+| garden_scrape_failure_total             | Total count of scraping failures, grouped by kind/group of metric(s)      | App      | Counter |
 
 ## Grafana Dashboards
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -95,6 +95,21 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 			nil,
 		),
 
+		metricGardenSeedCapacity: prometheus.NewDesc(
+			metricGardenSeedCapacity,
+			"Seed capacity.",
+			[]string{
+				"name",
+				"namespace",
+				"iaas",
+				"region",
+				"visible",
+				"protected",
+				"resource",
+			},
+			nil,
+		),
+
 		metricGardenShootCondition: prometheus.NewDesc(
 			metricGardenShootCondition,
 			"Condition state of a Shoot. Possible values: -1=Unknown|0=Unhealthy|1=Healthy|2=Progressing",

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -7,6 +7,7 @@ const (
 	// Seed metric
 	metricGardenSeedInfo      = "garden_seed_info"
 	metricGardenSeedCondition = "garden_seed_condition"
+	metricGardenSeedCapacity  = "garden_seed_capacity"
 
 	// Plant metric
 	metricGardenPlantInfo      = "garden_plant_info"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a metric `garden_seed_capacity` to export the capacity of a seed cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Currently `shoots` are the only resource.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add a metric `garden_seed_capacity` to export the capacity of a seed cluster.
```