### PR TITLE
Add `garden_seed_usage` metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -110,6 +110,21 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 			nil,
 		),
 
+		metricGardenSeedUsage: prometheus.NewDesc(
+			metricGardenSeedUsage,
+			"Seed usage.",
+			[]string{
+				"name",
+				"namespace",
+				"iaas",
+				"region",
+				"visible",
+				"protected",
+				"resource",
+			},
+			nil,
+		),
+
 		metricGardenShootCondition: prometheus.NewDesc(
 			metricGardenShootCondition,
 			"Condition state of a Shoot. Possible values: -1=Unknown|0=Unhealthy|1=Healthy|2=Progressing",

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -8,6 +8,7 @@ const (
 	metricGardenSeedInfo      = "garden_seed_info"
 	metricGardenSeedCondition = "garden_seed_condition"
 	metricGardenSeedCapacity  = "garden_seed_capacity"
+	metricGardenSeedUsage     = "garden_seed_usage"
 
 	// Plant metric
 	metricGardenPlantInfo      = "garden_plant_info"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `garden_seed_usage` metric to allow for better alerting regarding seed capacity. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add `garden_seed_usage` metric
```