### PR TITLE
Update REAME with `garden_seed_usage` metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The `gardener-metrics-exporter` is a [Prometheus][] metrics exporter for
 | garden_seed_info                        | Information to a Seed                                                     | Seed     | Gauge   |
 | garden_seed_capacity                    | Information regarding a seed's capacity with respect to certain resources | Seed     | Gauge   |
 | garden_seed_condition                   | Condition State of a Seed                                                 | Seed     | Gauge   |
+| garden_seed_usage                       | Actual usage of seed by resources                                         | Seed     | Gauge   |
 | garden_projects_status                  | Status of Garden Projects                                                 | Projects | Gauge   |
 | garden_users_total                      | Count of users                                                            | Users    | Gauge   |
 | garden_scrape_failure_total             | Total count of scraping failures, grouped by kind/group of metric(s)      | App      | Counter |


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the metric `garden_seed_usage` to the README documentation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```