### PR TITLE
fix bug with empty/duplicate condition in shoot and seed

### DIFF
--- a/pkg/metrics/seed.go
+++ b/pkg/metrics/seed.go
@@ -126,6 +126,9 @@ func (c gardenMetricsCollector) collectSeedMetrics(ch chan<- prometheus.Metric) 
 
 		// Export a metric for each condition of the Seed.
 		for _, condition := range seed.Status.Conditions {
+			if condition.Type == "" {
+				continue
+			}
 			metric, err := prometheus.NewConstMetric(
 				c.descs[metricGardenSeedCondition],
 				prometheus.GaugeValue,

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -218,6 +218,9 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 				if len(shoot.Status.LastErrors) > 0 {
 					hasErrors = true
 				}
+				if condition.Type == "" {
+					continue
+				}
 
 				metric, err := prometheus.NewConstMetric(
 					c.descs[metricGardenShootCondition],


### PR DESCRIPTION
**What this PR does / why we need it**:
In some seeds and shoots are two empty conditions:

```
...
status:
  conditions:
  - lastTransitionTime: null
    lastUpdateTime: null
    message: ""
    reason: ""
    status: ""
    type: ""
  - lastTransitionTime: null
    lastUpdateTime: null
    message: ""
    reason: ""
    status: ""
    type: ""
...

```


This results in an Prometheus error:

```
An error has occurred while serving metrics:
2 error(s) occurred:
* collected metric "garden_shoot_condition" { label:<name:"condition" value:"" > label:<name:"has_user_errors" value:"false" > label:<name:"iaas" value:"openstack" > label:<name:"is_compliant" value:"True" > label:<name:"is_seed" value:"true" > label:<name:"name" value:".." > label:<name:"operation" value:"Reconcile" > label:<name:"project" value:"garden" > label:<name:"purpose" value:"production" > label:<name:"seed_iaas" value:"openstack" > label:<name:"seed_region" value:"RegionOne" > label:<name:"uid" value:"...." > gauge:<value:-1 > } was collected before with the same name and label values
* collected metric "garden_seed_condition" { label:<name:"condition" value:"" > label:<name:"name" value:".." > gauge:<value:-1 > } was collected before with the same name and label values
```

Unfortunately i did not find a way to fix it in general if there are 2 duplicate conditions. But in our env i did not find some seed/shoot with duplicate conditions except for the empty one.

I am not sure if it fixes the linked issue completely but I think this empty conditions are "useless" so it should be okay to ignore them.

**Which issue(s) this PR fixes**:
Related to #35 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix bug with empty/duplicate condition in shoot and seed
```