### PR TITLE
Add initial managed seed support

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1391,6 +1391,7 @@ k8s.io/component-base v0.18.10/go.mod h1:ZzFXjzUBHKOcF0mnWkxBI1wDu5t+CV3GxXKKvHZ
 k8s.io/component-base v0.19.2/go.mod h1:g5LrsiTiabMLZ40AR6Hl45f088DevyGY+cCE2agEIVo=
 k8s.io/component-base v0.19.6/go.mod h1:8Btsf8J00/fVDa/YFmXjei7gVkcFrlKZXjSeP4SZNJg=
 k8s.io/component-base v0.21.1/go.mod h1:NgzFZ2qu4m1juby4TnrmpR8adRk6ka62YdH5DkIIyKA=
+k8s.io/component-base v0.21.2 h1:EsnmFFoJ86cEywC0DoIkAUiEV6fjgauNugiw1lmIjs4=
 k8s.io/component-base v0.21.2/go.mod h1:9lvmIThzdlrJj5Hp8Z/TOgIkdfsNARQ1pT+3PByuiuc=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/pkg/metrics/managed_seed.go
+++ b/pkg/metrics/managed_seed.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// collectManagedSeedMetrics collect managed seed metrics.
+func (c gardenMetricsCollector) collectManagedSeedMetrics(ch chan<- prometheus.Metric) {
+
+	managedSeeds, err := c.managedSeedInformer.Lister().ManagedSeeds(metav1.NamespaceAll).List(labels.Everything())
+	if err != nil {
+		ScrapeFailures.With(prometheus.Labels{"kind": "managedSeeds"}).Inc()
+		return
+	}
+
+	for _, ms := range managedSeeds {
+		// Some sanity checks.
+		if ms == nil || ms.Spec.Shoot == nil {
+			continue
+		}
+
+		// Expose a metric that exposes information about a managed seed.
+		metric, err := prometheus.NewConstMetric(
+			c.descs[metricGardenManagedSeedInfo],
+			prometheus.GaugeValue,
+			0,
+			[]string{
+				ms.Name,
+				ms.Spec.Shoot.Name,
+			}...,
+		)
+
+		if err != nil {
+			ScrapeFailures.With(prometheus.Labels{"kind": "managedSeeds"}).Inc()
+			return
+		}
+
+		ch <- metric
+	}
+}

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -63,6 +63,12 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 		return
 	}
 
+	managedSeeds, err := c.managedSeedInformer.Lister().ManagedSeeds(metav1.NamespaceAll).List(labels.Everything())
+	if err != nil {
+		ScrapeFailures.With(prometheus.Labels{"kind": "managedSeeds"}).Inc()
+		return
+	}
+
 	seeds := c.getSeeds()
 
 	collectShootCustomizationMetrics(shoots, ch)
@@ -80,7 +86,7 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 			iaas = shoot.Spec.Provider.Type
 			seed = *shoot.Spec.SeedName
 		)
-		isSeed = usedAsSeed(shoot)
+		isSeed = usedAsSeed(shoot, managedSeeds)
 
 		if shoot.Spec.Purpose != nil {
 			purpose = string(*shoot.Spec.Purpose)

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -5,10 +5,11 @@ const (
 	metricGardenUsersSum       = "garden_users_total"
 
 	// Seed metric
-	metricGardenSeedInfo      = "garden_seed_info"
-	metricGardenSeedCondition = "garden_seed_condition"
-	metricGardenSeedCapacity  = "garden_seed_capacity"
-	metricGardenSeedUsage     = "garden_seed_usage"
+	metricGardenManagedSeedInfo = "garden_managed_seed_info"
+	metricGardenSeedInfo        = "garden_seed_info"
+	metricGardenSeedCondition   = "garden_seed_condition"
+	metricGardenSeedCapacity    = "garden_seed_capacity"
+	metricGardenSeedUsage       = "garden_seed_usage"
 
 	// Plant metric
 	metricGardenPlantInfo      = "garden_plant_info"

--- a/pkg/metrics/utils.go
+++ b/pkg/metrics/utils.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+
 	constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,15 +48,17 @@ func mapConditionStatus(status gardenv1beta1.ConditionStatus) float64 {
 	}
 }
 
-func usedAsSeed(shoot *gardenv1beta1.Shoot) bool {
+func usedAsSeed(shoot *gardenv1beta1.Shoot, managedSeeds []*seedmanagementv1alpha1.ManagedSeed) bool {
 	if shoot.Namespace != constants.GardenNamespace {
 		return false
 	}
-	_, ok := shoot.Annotations[constants.AnnotationShootUseAsSeed]
-	if !ok {
-		return false
+	for _, ms := range managedSeeds {
+		if ms.Spec.Shoot.Name == shoot.Name && ms.Namespace == shoot.Namespace {
+			return true
+		}
 	}
-	return true
+
+	return false
 }
 
 func findProject(projects []*gardenv1beta1.Project, match string) (*string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #56

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add initial metrics for managed seeds
```

```improvement operator
Add `garden_managed_seed_info` metric
```

```improvement operator
Fix an issue where the `is_seed` label was not set properly
```