### PR TITLE
Add cri and container_runtime to shoot_node_info

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -222,6 +222,8 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"worker_group",
 				"image",
 				"version",
+				"cri",
+				"container_runtimes",
 			},
 			nil,
 		),

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -283,6 +283,18 @@ func (c gardenMetricsCollector) collectShootNodeMetrics(shoot *gardenv1beta1.Sho
 		nodeCountMax += worker.Minimum
 		nodeCountMin += worker.Maximum
 
+		var criName string
+		var containerRuntimes []string
+
+		if worker.CRI == nil {
+			criName = "docker (default)"
+		} else {
+			criName = string(worker.CRI.Name)
+			for _, runtime := range worker.CRI.ContainerRuntimes {
+				containerRuntimes = append(containerRuntimes, runtime.Type)
+			}
+		}
+
 		// Expose metrics about the Shoot's nodes.
 		metric, err := prometheus.NewConstMetric(
 			c.descs[metricGardenShootNodeInfo],
@@ -294,6 +306,8 @@ func (c gardenMetricsCollector) collectShootNodeMetrics(shoot *gardenv1beta1.Sho
 				worker.Name,
 				worker.Machine.Image.Name,
 				*worker.Machine.Image.Version,
+				criName,
+				strings.Join(containerRuntimes, ", "),
 			}...,
 		)
 		if err != nil {

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -17,6 +17,7 @@ package metrics
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -293,6 +294,7 @@ func (c gardenMetricsCollector) collectShootNodeMetrics(shoot *gardenv1beta1.Sho
 			for _, runtime := range worker.CRI.ContainerRuntimes {
 				containerRuntimes = append(containerRuntimes, runtime.Type)
 			}
+			sort.Strings(containerRuntimes)
 		}
 
 		// Expose metrics about the Shoot's nodes.


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds information about the CRI worker pool configuration to `shoot_node_info`, looking like this

```
$ curl http://localhost:2719/metrics | grep garden_shoot_node_info

# HELP garden_shoot_node_info Information about the nodes in a Shoot.
# TYPE garden_shoot_node_info gauge
garden_shoot_node_info{container_runtimes="",cri="docker (default)",image="flatcar",name="marco-test-shoot",project="dev",version="2765.2.6",worker_group="fc-docker"} 0
garden_shoot_node_info{container_runtimes="gvisor",cri="containerd",image="flatcar",name="marco-test-shoot",project="dev",version="2765.2.6",worker_group="fc-contd-new"} 0
```

The following cases are considered:
* The node pool cri is configured explicitly with either `.spec.provider.workers[].cri.name: docker` or `.spec.provider.workers[].cri.name: containerd`. This value is directly put into the `cri` label
* The node pool cri is not configured explicitly and `.spec.provider.workers[].cri: nil`. In this case, we insert `docker (default)` in the label to distinguish from the explicit configuration option above. This can only be the case for k8s versions < 1.22 – afterwards a value of `nil` is defaulted to `containerd`.
* The list of container runtimes at `.spec.provider.workers[].cri.containerruntimes[]` can be nil or contain an arbitrary number of elements. The `type` field values will be concatenated with ", " and put into the `container_runtimes` label.

**Which issue(s) this PR fixes**:
related gardener/gardener#4110

**Special notes for your reviewer**:
We probably want a dashboard for this, just for convenience – I'm just not sure how to develop that, tbh.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
`shoot_node_info` contains two new labels: `cri`, containing the worker pool's cri configuration configured at `.spec.provider.workers[].cri.name` and `container_runtimes`, containing a comma-separated list of all supported runtimes configured at `.spec.provider.workers[].cri.containerruntimes[]`.
```