### PR TITLE
Add seed name to the condition metric for shoots

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -148,6 +148,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"purpose",
 				"is_seed",
 				"iaas",
+				"seed",
 				"seed_iaas",
 				"seed_region",
 				"uid",

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -241,6 +241,7 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 						purpose,
 						strconv.FormatBool(isSeed),
 						iaas,
+						seed,
 						seeds[*shoot.Spec.SeedName].Spec.Provider.Type,
 						seeds[*shoot.Spec.SeedName].Spec.Provider.Region,
 						uid,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the Seed name information to the `garden_shoot_condition` metric as an additional label.
The label value should be rather stable (should only change during control plane migration and on creation once the schedules find a proper Seed for the Shoot) and should therefore not produce additional time series.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Information about the Seed which host the control plane of a Shoot has been added to the `garden_shoot_condition` metric.
```

/invite @wyb1 