### PR TITLE
add custom purpose label for special canary clusters

### DIFF
--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -93,6 +93,14 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 			purpose = string(*shoot.Spec.Purpose)
 		}
 
+		if shoot.ObjectMeta.Labels != nil {
+			for k, v := range shoot.ObjectMeta.Labels {
+				if k == "business-critical" && v == "true" {
+					purpose = "business-critical"
+				}
+			}
+		}
+
 		projectName, err := findProject(projects, shoot.Namespace)
 		if err != nil {
 			c.logger.Error(err.Error())


### PR DESCRIPTION
**What this PR does / why we need it**:
add custom purpose label to alert on special canary clusters
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
add custom purpose label to alert on special canary clusters
```