### PR TITLE
Add the k8s version to the garden_seed_info metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -103,6 +103,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"region",
 				"visible",
 				"protected",
+				"version",
 			},
 			nil,
 		),

--- a/pkg/metrics/seed.go
+++ b/pkg/metrics/seed.go
@@ -72,6 +72,7 @@ func (c gardenMetricsCollector) collectSeedMetrics(ch chan<- prometheus.Metric) 
 				seed.Spec.Provider.Region,
 				strconv.FormatBool(visible),
 				strconv.FormatBool(protected),
+				getK8sVersion(seed),
 			}...,
 		)
 		if err != nil {
@@ -145,4 +146,12 @@ func (c gardenMetricsCollector) collectSeedMetrics(ch chan<- prometheus.Metric) 
 			ch <- metric
 		}
 	}
+}
+
+func getK8sVersion(seed *gardenv1beta1.Seed) string {
+	version := ""
+	if seed.Status.KubernetesVersion != nil {
+		version = *seed.Status.KubernetesVersion
+	}
+	return version
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the k8s version to the garden_seed_info metric. Currently it was only possible to get the k8s version from the garden_shoot_info metric, but if a seed cluster is not a shoot we could not access this information via the metrics.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add the k8s version to the garden_seed_info metric
```