### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
   cmd/main.go
 
 #############      gardener-metrics-exporter     #############
-FROM alpine:3.14.6 AS metrics-exporter
+FROM gcr.io/distroless/static-debian11:nonroot AS metrics-exporter
 
 COPY --from=builder /go/bin/gardener-metrics-exporter /gardener-metrics-exporter
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the base image for the metrics exporter from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The processes will now use a non root user for their execution. This will reduce the attack surface of the image.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The `gardener-metrics-exporter` now uses `distroless` instead of `alpine` as a base image.
```