### PR TITLE
The metrics exporter should fail if it is unable to ListenAndServe

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,6 +64,6 @@ func Serve(ctx context.Context, bindAddress string, port int, logger *logrus.Log
 
 	logger.Infof("Starting webserver on port %d...", port)
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		logger.Errorf("Server starting error. %s", err.Error())
+		logger.Fatalf("Server starting error. %s", err.Error())
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```