### PR TITLE
Allow access to secret binding objects

### DIFF
--- a/charts/gardener-metrics-exporter/charts/application/templates/clusterrole.yaml
+++ b/charts/gardener-metrics-exporter/charts/application/templates/clusterrole.yaml
@@ -9,6 +9,7 @@ rules:
   - shoots
   - projects
   - seeds
+  - secretbindings
   verbs:
   - get
   - watch


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow access to secret binding objects

Should have been part of this commit:
https://github.com/gardener/gardener-metrics-exporter/pull/79/commits/adc099fed64f4732af6f03872294b411c6a516b1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Allow access to secret binding objects
```