### PR TITLE
Extended HELM Chart by a couple best practices

### DIFF
--- a/charts/gardener-metrics-exporter/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-metrics-exporter/charts/runtime/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: gardener-metrics-exporter
         image: "{{ include "image" .Values.global.image }}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         command:
         - /gardener-metrics-exporter
         {{- if .Values.global.kubeconfig }}
@@ -66,10 +66,24 @@ spec:
         ports:
         - name: port
           containerPort: {{ .Values.global.server.port }}
+        {{- if .Values.global.resources }}
         resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
+          {{- toYaml .Values.global.resources | nindent 10 }}
+        {{- end }}
+        {{- if .Values.global.securityContext }}
+        securityContext:
+          {{- toYaml .Values.global.securityContext | nindent 10 }}
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 2718
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 2718
+          periodSeconds: 5
       {{- if or .Values.global.kubeconfig .Values.global.serviceAccountTokenVolumeProjection.enabled }}
       volumes:
       {{- end }}

--- a/charts/gardener-metrics-exporter/values.yaml
+++ b/charts/gardener-metrics-exporter/values.yaml
@@ -17,6 +17,9 @@ global:
       cpu: 100m
       memory: 128Mi
 
+  securityContext:
+    readOnlyRootFilesystem: true
+
   serviceAccountTokenVolumeProjection:
     enabled: false
     expirationSeconds: 43200

--- a/charts/gardener-metrics-exporter/values.yaml
+++ b/charts/gardener-metrics-exporter/values.yaml
@@ -17,10 +17,6 @@ global:
       cpu: 100m
       memory: 128Mi
 
-  securityContext:
-    runAsUser: 10001
-    runAsGroup: 10001
-
   serviceAccountTokenVolumeProjection:
     enabled: false
     expirationSeconds: 43200

--- a/charts/gardener-metrics-exporter/values.yaml
+++ b/charts/gardener-metrics-exporter/values.yaml
@@ -9,7 +9,17 @@ global:
   image:
     repository: eu.gcr.io/gardener-project/gardener/metrics-exporter
     tag: latest
+    pullPolicy: IfNotPresent
   # kubeconfig: a3ViZWNvbmZpZwo=
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  securityContext:
+    runAsUser: 10001
+    runAsGroup: 10001
 
   serviceAccountTokenVolumeProjection:
     enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows the operator to configure:
- Image Pull Policy
- Resource Requests / Limits
- (Container) SecurityContext

This PR also adds a liveness- and readiness probe to the deployment.

**Release note**:
```improvement operator
Resources, SecurityContext and Image Pull Policy can be configured via the HELM chart.
"gardener-metrics-exporter" container now has a liveness- and readiness probe.
```