### PR TITLE
Remove the use of the enableBasicAuthentication field

### DIFF
--- a/dashboards/shoot-customization-dashboard.json
+++ b/dashboards/shoot-customization-dashboard.json
@@ -824,91 +824,6 @@
       ],
       "datasource": "cluster-prometheus",
       "decimals": null,
-      "description": "Count of Shoots which have basic auth enabled on the kube apiserver.",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 14
-      },
-      "id": 19,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true
-      },
-      "tableColumn": "__name__",
-      "targets": [
-        {
-          "expr": "garden_shoots_custom_apiserver_basicauth_total",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "intervalFactor": 2,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "title": "Shoot apiservers with Basic Auth",
-      "type": "singlestat",
-      "valueFontSize": "70%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "",
-          "value": ""
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#d44a3a",
-        "rgba(40, 40, 40, 0.89)",
-        "#299c46"
-      ],
-      "datasource": "cluster-prometheus",
-      "decimals": null,
       "description": "Count of Shoots which have an audit log policy configured for the kube apiserver.",
       "format": "none",
       "gauge": {
@@ -920,8 +835,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 6,
+        "w": 9,
+        "x": 0,
         "y": 14
       },
       "id": 20,
@@ -1005,8 +920,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 12,
+        "w": 9,
+        "x": 9,
         "y": 14
       },
       "id": 21,

--- a/pkg/metrics/shoot_customization.go
+++ b/pkg/metrics/shoot_customization.go
@@ -76,25 +76,6 @@ var shootCustomizationMetrics = []*template.MetricTemplate{
 
 	// Kube API Server customization.
 	{
-		Name:   fmt.Sprintf("%s_apiserver_basicauth_total", metricShootsCustomPrefix),
-		Help:   "Count of Shoots which have basic auth enabled on the kube apiserver.",
-		Labels: []string{},
-		Type:   template.Gauge,
-		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
-			shoots, ok := obj.([]*gardenv1beta1.Shoot)
-			if !ok {
-				return nil, nil, utils.NewTypeConversionError()
-			}
-			var counter = make([]float64, 1, 1)
-			for _, s := range shoots {
-				if s.Spec.Kubernetes.KubeAPIServer != nil && s.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication != nil && *s.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication {
-					counter[0]++
-				}
-			}
-			return &counter, &[][]string{}, nil
-		},
-	},
-	{
 		Name:   fmt.Sprintf("%s_apiserver_auditpolicy_total", metricShootsCustomPrefix),
 		Help:   "Count of Shoots which have an audit log policy configured for the kube apiserver.",
 		Labels: []string{},


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the use of the enableBasicAuthentication field

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6911

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Remove the no longer needed customization metric `garden_shoots_custom_apiserver_basicauth_total` which was used to count the shoots which have basic auth enabled on the kube apiserver. It is not possible to enable basic auth anymore for a Shoot with a K8s version that is supported by Gardener.
```