### PR TITLE
Add migrate and restore types to ShootOperations

### DIFF
--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -30,10 +30,12 @@ import (
 var (
 	shootHealthProbeResponseTimeRegExp *regexp.Regexp
 
-	shootOperations = [3]string{
+	shootOperations = [5]string{
 		string(gardenv1beta1.LastOperationTypeCreate),
 		string(gardenv1beta1.LastOperationTypeReconcile),
 		string(gardenv1beta1.LastOperationTypeDelete),
+		string(gardenv1beta1.LastOperationTypeMigrate),
+		string(gardenv1beta1.LastOperationTypeRestore),
 	}
 
 	userErrorCodes = map[gardenv1beta1.ErrorCode]bool{


### PR DESCRIPTION
**What this PR does / why we need it**:

For shoot migrations at a larger scale, it is important to have some metrics regarding their state. Therefore, it would be helpful to have not only the states `Create`, `Reconcile` and `Delete` as operation labels, but also `Migrate` and `Restore`. This is e.g. used for the metric `garden_shoot_operation_states`.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The shoot operation states `Migrate` and `Restore` are now reported as well.
```

cc @timebertt