### PR TITLE
Add cond msg field to garden_shoot_condition metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -120,6 +120,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"name",
 				"project",
 				"condition",
+				"condition_msg",
 				"operation",
 				"purpose",
 				"is_seed",

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -282,6 +282,14 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 					continue
 				}
 
+				condMsg := ""
+				if (mapConditionStatus(condition.Status) == 0) {
+					condMsg = string(condition.Message)
+					if len(condMsg) > 100 {
+						condMsg = condMsg[:100]
+					}
+				}
+
 				metric, err := prometheus.NewConstMetric(
 					c.descs[metricGardenShootCondition],
 					prometheus.GaugeValue,
@@ -290,6 +298,7 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 						shoot.Name,
 						*projectName,
 						string(condition.Type),
+						condMsg,
 						lastOperation,
 						purpose,
 						strconv.FormatBool(isSeed),


### PR DESCRIPTION
**What this PR does / why we need it**:
Expose the condition message field to garden_shoot_condition metric as metadata to the condition type.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Expose the condition message field to garden_shoot_condition metric as metadata to the condition type.
```