### PR TITLE
Fix nodeCountMax and nodeCountMinimum where the wrong value is counted (they are switched)

### DIFF
--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -346,8 +346,8 @@ func (c gardenMetricsCollector) collectShootNodeMetrics(shoot *gardenv1beta1.Sho
 
 	workers := shoot.Spec.Provider.Workers
 	for _, worker := range workers {
-		nodeCountMax += worker.Minimum
-		nodeCountMin += worker.Maximum
+		nodeCountMax += worker.Maximum
+		nodeCountMin += worker.Minimum
 
 		var criName string
 		var containerRuntimes []string


### PR DESCRIPTION
Fix nodeCountMax and nodeCountMinimum where the wrong value is counted (they are switched)

**What this PR does / why we need it**:
- nodeCountMax and nodeCountMinimum are counted wrongly. Data for minimum is inserted in maximum and maximum in minimum

**Which issue(s) this PR fixes**:
Fixes #89

**Special notes for your reviewer**:

**Release note**:
```
Correctly counting the minimum and maximum shoot nodes instead of counting minimum at maximum and maximum at minimum. 
```