### PR TITLE
switch GCR -> Artifact-Registry 

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -4,10 +4,12 @@ metrics-exporter:
       version:
         preprocess: inject-commit-hash
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         dockerimages:
           metrics-exporter:
-            image: eu.gcr.io/gardener-project/gardener/metrics-exporter
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/metrics-exporter
             dockerfile: Dockerfile
             target: metrics-exporter
             tag_as_latest: true
@@ -18,15 +20,21 @@ metrics-exporter:
     head-update:
       traits:
         draft_release: ~
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
     pull-request:
       traits:
         pull-request: ~
-        component_descriptor: ~
     release:
       traits:
         version:
           preprocess: finalize
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            metrics-exporter:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/metrics-exporter
         release:
           nextversion: bump_minor
-        component_descriptor: ~

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 metrics-exporter:
-  template: default
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess: inject-commit-hash
@@ -9,7 +7,6 @@ metrics-exporter:
       publish:
         dockerimages:
           metrics-exporter:
-            registry: gcr-readwrite
             image: eu.gcr.io/gardener-project/gardener/metrics-exporter
             dockerfile: Dockerfile
             target: metrics-exporter

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_REPOSITORY := eu.gcr.io/gardener-project/gardener/metrics-exporter
+IMAGE_REPOSITORY := europe-docker.pkg.dev/gardener-project/public/gardener/metrics-exporter
 IMAGE_VERSION    := $(shell cat VERSION)
 WORKDIR          := $(shell pwd)
 HOMEDIR          := $(shell echo ${HOME})

--- a/charts/gardener-metrics-exporter/values.yaml
+++ b/charts/gardener-metrics-exporter/values.yaml
@@ -7,7 +7,7 @@ global:
     bindAddress: 0.0.0.0
     port: 2718
   image:
-    repository: eu.gcr.io/gardener-project/gardener/metrics-exporter
+    repository: europe-docker.pkg.dev/gardener-project/public/gardener/metrics-exporter
     tag: latest
     pullPolicy: IfNotPresent
   # kubeconfig: a3ViZWNvbmZpZwo=


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
