### PR TITLE
Fix chart upgrades

### DIFF
--- a/charts/gardener-metrics-exporter/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-metrics-exporter/charts/runtime/templates/deployment.yaml
@@ -13,7 +13,6 @@ spec:
     matchLabels:
       app: gardener
       role: metrics-exporter
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
       release: "{{ .Release.Name }}"
       heritage: "{{ .Release.Service }}"
   template:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes chart upgrades by removing the version-specific label from the deployment's selector.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-metrics-exporter/issues/93

**Special notes for your reviewer**:

Upgrading to a new version including this PR will require operators to delete the Deployment first, so that helm allows the upgrade.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```bugfix operator
Helm chart upgrades no longer fail due to the immutable `Deployment.spec.selector` field. In order to upgrade to this version, the `gardener-metrics-exporter` Deployment needs to be deleted first.
```