### PR TITLE
Add `garden_version` to `garden_shoot_info` metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -163,6 +163,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"cost_object",
 				"cost_object_owner",
 				"failure_tolerance",
+				"garden_version",
 			},
 			nil,
 		),

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -157,6 +157,7 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 				costObject,
 				costObjectOwner,
 				failureTolerance,
+				shoot.Status.Gardener.Version,
 			}...,
 		)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new label (`garden_version`) to the `garden_shoot_info` metric.
The new label contains the value of the `.status.gardener.version` field of the shoots.

It can be used to monitor rollouts, e.g., to see how many shoots were already reconciled with a new version.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add garden_version to the garden_shoot_info metric
```