### PR TITLE
Rename `garden_version` label to `gardener_version`

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -163,7 +163,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"cost_object",
 				"cost_object_owner",
 				"failure_tolerance",
-				"garden_version",
+				"gardener_version",
 			},
 			nil,
 		),


### PR DESCRIPTION
**What this PR does / why we need it**:

In #101, a new label was introduced to export the gardener version in the `garden_shoot_info` metric. We were a little too quick to merge it - the label name should have followed the Shoot CRD naming convention to be `gardener_version` rather than `garden_version`.

**Special notes for your reviewer**:
FYI @Kumm-Kai 
/cc @istvanballok @vicwicker 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Rename `garden_version` label to `gardener_version` on `garden_shoot_info` metric.
```