### PR TITLE
Fix costObject retrieval for workerless shoots

### DIFF
--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -93,11 +93,16 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 			secretBindingName = fmt.Sprintf("%s/%s", shoot.Namespace, *shoot.Spec.SecretBindingName)
 		}
 
+		var projectNamespace string
 		if secretBinding, ok := secretBindingMap[secretBindingName]; ok {
-			if project, ok := projectMap[secretBinding.SecretRef.Namespace]; ok {
-				costObject = project.GetObjectMeta().GetAnnotations()["billing.gardener.cloud/costObject"]
-				costObjectOwner = project.Spec.Owner.Name
-			}
+			projectNamespace = secretBinding.SecretRef.Namespace
+		} else {
+			projectNamespace = shoot.Namespace
+		}
+
+		if project, ok := projectMap[projectNamespace]; ok {
+			costObject = project.GetObjectMeta().GetAnnotations()["billing.gardener.cloud/costObject"]
+			costObjectOwner = project.Spec.Owner.Name
 		}
 
 		var failureTolerance string


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, the billing information was not copied at all if the shoot was workerless (i.e., it does not have a `secretBindingName`). This PR fixes the heuristic to find a costObject for the shoot by using the billing information in the project of the shoot itself if a shoot is workerless.

**Special notes for your reviewer**:
/cc @istvanballok 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The costObject for workerless shoots is now determined correctly.
```