### PR TITLE
Add `is_workerless` label to shoot_info

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -164,6 +164,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"cost_object_owner",
 				"failure_tolerance",
 				"gardener_version",
+				"is_workerless",
 			},
 			nil,
 		),

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -143,6 +143,8 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 			seedRegion = seeds[seed].Spec.Provider.Region
 		}
 
+		isWorkerless := shoot.Spec.Provider.Workers == nil
+
 		// Expose a metric, which transport basic information to the Shoot cluster via the metric labels.
 		metric, err := prometheus.NewConstMetric(
 			c.descs[metricGardenShootInfo],
@@ -163,6 +165,7 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 				costObjectOwner,
 				failureTolerance,
 				shoot.Status.Gardener.Version,
+				strconv.FormatBool(isWorkerless),
 			}...,
 		)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new label (`is_workerless`) to the `garden_shoot_info` metric.
For the new label there is a check if the value: `shoot.Spec.Provider.Workers` does not exist. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vicwicker 

**Release note**:

```Add is_workerless to the garden_shoot_info metric```