### PR TITLE
Add `is_hibernated` label to `garden_shoot_info`

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -165,6 +165,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"failure_tolerance",
 				"gardener_version",
 				"is_workerless",
+				"is_hibernated",
 			},
 			nil,
 		),

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -166,6 +166,7 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 				failureTolerance,
 				shoot.Status.Gardener.Version,
 				strconv.FormatBool(isWorkerless),
+				strconv.FormatBool(shoot.Status.IsHibernated),
 			}...,
 		)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an extra label to the `garden_shoot_info` about the hibernation state of a cluster.

**Release note**:
```improvement operator
Add `is_hibernated` to the `garden_shoot_info` metric
```