### PR TITLE
Update readme and fix naming for `garden_shoot_node_info`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The `gardener-metrics-exporter` is a [Prometheus][] metrics exporter for
 | garden_shoot_worker_node_min_total      | Min node count of a Shoot worker group                                    | Shoot    | Gauge   |
 | garden_shoot_worker_node_max_total      | Max node count of a Shoot worker group                                    | Shoot    | Gauge   |
 | garden_shoot_operations_total           | Count of ongoing operations                                               | Shoot    | Gauge   |
-| garden_shoot_operation_states           | Operation State of a Shoot                                                | Shoot    | Gauge   |
 | garden_shoot_operation_progress_percent | Operation Percentage of a Shoot                                           | Shoot    | Gauge   |
 | garden_seed_info                        | Information to a Seed                                                     | Seed     | Gauge   |
 | garden_seed_capacity                    | Information regarding a seed's capacity with respect to certain resources | Seed     | Gauge   |

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The `gardener-metrics-exporter` is a [Prometheus][] metrics exporter for
 | garden_shoot_operation_states           | Operation state of a Shoot                                                | Shoot    | Gauge   |
 | garden_shoot_info                       | Information to a Shoot                                                    | Shoot    | Gauge   |
 | garden_shoot_condition                  | Condition state of a Shoot                                                | Shoot    | Gauge   |
+| garden_shoot_worker_node_info           | Node information of a Shoot worker group                                  | Shoot    | Gauge   |
 | garden_shoot_node_min_total             | Min node count of a Shoot                                                 | Shoot    | Gauge   |
 | garden_shoot_node_max_total             | Max node count of a Shoot                                                 | Shoot    | Gauge   |
 | garden_shoot_worker_node_min_total      | Min node count of a Shoot worker group                                    | Shoot    | Gauge   |

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -210,9 +210,9 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 			nil,
 		),
 
-		metricGardenShootNodeInfo: prometheus.NewDesc(
-			metricGardenShootNodeInfo,
-			"Information about the nodes in a Shoot.",
+		metricGardenShootWorkerNodeInfo: prometheus.NewDesc(
+			metricGardenShootWorkerNodeInfo,
+			"Information about the worker group nodes in a Shoot.",
 			[]string{
 				"name",
 				"project",

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -402,7 +402,7 @@ func (c gardenMetricsCollector) collectShootNodeMetrics(shoot *gardenv1beta1.Sho
 
 		// Expose metrics about the Shoot's nodes.
 		metric, err = prometheus.NewConstMetric(
-			c.descs[metricGardenShootNodeInfo],
+			c.descs[metricGardenShootWorkerNodeInfo],
 			prometheus.GaugeValue,
 			0,
 			[]string{

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -24,6 +24,6 @@ const (
 	metricGardenShootWorkerNodeMinTotal       = "garden_shoot_worker_node_min_total"
 
 	// Aggregated Shoot metrics (exclude Shoots which act as Seed).
-	metricGardenOperationsTotal = "garden_shoot_operations_total"
-	metricGardenShootNodeInfo   = "garden_shoot_node_info"
+	metricGardenOperationsTotal     = "garden_shoot_operations_total"
+	metricGardenShootWorkerNodeInfo = "garden_shoot_worker_node_info"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes a duplicate line the readme for the metric `garden_shoot_operation_states` and renames the metric `garden_shoot_node_info` to `garden_shoot_worker_node_info`. The new naming is what the metric really is about, the worker group info and not all nodes in the shoot cluster.

**Which issue(s) this PR fixes**:
Fixes #98

**Release note**:
```improvement operator
Update readme
renames the metric `garden_shoot_node_info` to `garden_shoot_worker_node_info`
```