### PR TITLE
remove duplicate metric from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The `gardener-metrics-exporter` is a [Prometheus][] metrics exporter for
 | garden_shoot_worker_node_min_total      | Min node count of a Shoot worker group                                    | Shoot    | Gauge   |
 | garden_shoot_worker_node_max_total      | Max node count of a Shoot worker group                                    | Shoot    | Gauge   |
 | garden_shoot_operations_total           | Count of ongoing operations                                               | Shoot    | Gauge   |
-| garden_shoot_operation_states           | Operation State of a Shoot                                                | Shoot    | Gauge   |
 | garden_shoot_operation_progress_percent | Operation Percentage of a Shoot                                           | Shoot    | Gauge   |
 | garden_seed_info                        | Information to a Seed                                                     | Seed     | Gauge   |
 | garden_seed_capacity                    | Information regarding a seed's capacity with respect to certain resources | Seed     | Gauge   |


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes a duplicate line the readme for the metric garden_shoot_operation_states

**Release note**:

```improvement user
Remove duplicated metrics from README
```