### PR TITLE
Add cost_object_type label to garden_shoot_info metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -164,6 +164,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"seed_region",
 				"shoot_uid",
 				"cost_object",
+				"cost_object_type",
 				"cost_object_owner",
 				"failure_tolerance",
 				"technical_id",

--- a/pkg/metrics/shoot.go
+++ b/pkg/metrics/shoot.go
@@ -87,7 +87,7 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 	}
 
 	for _, shoot := range shoots {
-		var costObject, costObjectOwner, secretBindingName string
+		var costObject, costObjectType, costObjectOwner, secretBindingName string
 
 		if shoot.Spec.SecretBindingName != nil {
 			secretBindingName = fmt.Sprintf("%s/%s", shoot.Namespace, *shoot.Spec.SecretBindingName)
@@ -102,6 +102,7 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 
 		if project, ok := projectMap[projectNamespace]; ok {
 			costObject = project.GetObjectMeta().GetAnnotations()["billing.gardener.cloud/costObject"]
+			costObjectType = project.GetObjectMeta().GetAnnotations()["billing.gardener.cloud/costObjectType"]
 			costObjectOwner = project.Spec.Owner.Name
 		}
 
@@ -162,6 +163,7 @@ func (c gardenMetricsCollector) collectShootMetrics(ch chan<- prometheus.Metric)
 				seedRegion,
 				string(shoot.UID),
 				costObject,
+				costObjectType,
 				costObjectOwner,
 				failureTolerance,
 				shoot.Status.TechnicalID,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add cost_object_type label to garden_shoot_info metric

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @istvanballok @vicwicker 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add cost_object_type label to garden_shoot_info metric
```