### PR TITLE
fix missing technical_id label for metricGardenShootWorkerNodeMinTotal

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -216,6 +216,7 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"project",
 				"worker_group",
 				"worker_machine_type",
+				"technical_id",
 			},
 			nil,
 		),


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #115

**Special notes for your reviewer**:

The fix can be tested by verifying that the metrics are not present with `v0.31.0` - `v0.33.0` when querying the `/metrics` endpoint. 

The metrics are present again with this fix. 
Also the `garden_scrape_failure_total{kind="shoots"}` will not increase anymore. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```bugfix operator
fix some node related metrics not scraped
```