### PR TITLE
Update Go image to 1.24

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -15,9 +15,9 @@ metrics-exporter:
             tag_as_latest: true
     steps:
       check:
-        image: 'golang:1.22'
+        image: 'golang:1.24'
       sast:
-        image: 'golang:1.22'
+        image: 'golang:1.24'
   jobs:
     head-update:
       traits:

--- a/.ci/sast
+++ b/.ci/sast
@@ -36,7 +36,7 @@ parse_flags() {
 # Install Gosec.
 if ! which gosec 1>/dev/null; then
   echo -n "Installing gosec... "
-  GO111MODULE=on go install github.com/securego/gosec/v2/cmd/gosec@latest
+  GO111MODULE=on go install github.com/securego/gosec/v2/cmd/gosec@v2.22.1
 fi
 
 parse_flags "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #####################      builder       #####################
-FROM golang:1.22 AS builder
+FROM golang:1.24 AS builder
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/gardener/gardener-metrics-exporter


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Go image to 1.24 for pipelines and build base image to allow updating dependencies to latest version.

The gosec version in pinned by this PR to solve incompatibility issues between the Golang and gosec version.

**Which issue(s) this PR fixes**:
Fixes compatibility issues with #122

**Special notes for your reviewer**:
/cc @istvanballok @rickardsjp @vicwicker 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```