### PR TITLE
Remove gardener_shoot_custom_privileged_containers_total metric

### DIFF
--- a/pkg/metrics/shoot_customization.go
+++ b/pkg/metrics/shoot_customization.go
@@ -21,26 +21,6 @@ const (
 var shootCustomizationMetrics = []*template.MetricTemplate{
 	// General customization.
 	{
-		Name:   fmt.Sprintf("%s_privileged_containers_total", metricShootsCustomPrefix),
-		Help:   "Count of Shoots which allow privileged containers.",
-		Labels: []string{},
-		Type:   template.Gauge,
-		CollectFunc: func(obj interface{}, params ...interface{}) (*[]float64, *[][]string, error) {
-			shoots, ok := obj.([]*gardenv1beta1.Shoot)
-			if !ok {
-				return nil, nil, utils.NewTypeConversionError()
-			}
-			var counter = make([]float64, 1)
-			for _, s := range shoots {
-				if s.Spec.Kubernetes.AllowPrivilegedContainers != nil && *s.Spec.Kubernetes.AllowPrivilegedContainers {
-					counter[0]++
-				}
-			}
-			return &counter, &[][]string{}, nil
-		},
-	},
-
-	{
 		Name:   fmt.Sprintf("%s_extensions_total", metricShootsCustomPrefix),
 		Help:   "Count of Shoots which have an extension(s) configured.",
 		Labels: []string{"extension"},


### PR DESCRIPTION
**What this PR does / why we need it**:

The corresponding flag to allow or disallow privileged containers has been remove from the Shoot API with PR
https://github.com/gardener/gardener/pull/9274.

**Which issue(s) this PR fixes**:
Follow-up of https://github.com/gardener/gardener/pull/9274

**Special notes for your reviewer**:
/cc @rickardsjp @vicwicker @istvanballok @shafeeqes

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Remove gardener_shoot_custom_privileged_containers_total metric
```