### PR TITLE
Add support for `CredentialsBinding` resources to identify shoot cost objects

### DIFF
--- a/cmd/gardener-metrics-exporter/app.go
+++ b/cmd/gardener-metrics-exporter/app.go
@@ -124,6 +124,7 @@ func run(ctx context.Context, o *options) error {
 		gardenInformerFactory.Core().V1beta1().Projects(),
 		gardenManagedSeedInformerFactory.Seedmanagement().V1alpha1().ManagedSeeds(),
 		gardenInformerFactory.Core().V1beta1().SecretBindings(),
+		gardenSecurityInformerFactory.Security().V1alpha1().CredentialsBindings(),
 		log,
 	)
 

--- a/cmd/gardener-metrics-exporter/app.go
+++ b/cmd/gardener-metrics-exporter/app.go
@@ -86,7 +86,7 @@ func run(ctx context.Context, o *options) error {
 	stopCh := make(chan struct{})
 
 	// Create informer factories to create informers.
-	gardenInformerFactory, gardenManagedSeedInformerFactory, gardenSecurityInformerFactory, err := setupInformerFactories(o.kubeconfigPath, stopCh)
+	gardenInformerFactory, gardenManagedSeedInformerFactory, gardenSecurityInformerFactory, err := setupInformerFactories(o.kubeconfigPath)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func run(ctx context.Context, o *options) error {
 		return errors.New("Timed out waiting for Garden caches to sync")
 	}
 
-	gardenManagedSeedInformerFactory.Start((stopCh))
+	gardenManagedSeedInformerFactory.Start(stopCh)
 	if !cache.WaitForCacheSync(ctx.Done(), managedSeedInformer.HasSynced) {
 		return errors.New("Timed out waiting for Managed Seed caches to sync")
 	}
@@ -168,7 +168,7 @@ func newClientConfig(kubeconfigPath string) (*rest.Config, error) {
 	return client, nil
 }
 
-func setupInformerFactories(kubeconfigPath string, stopCh <-chan struct{}) (gardencoreinformers.SharedInformerFactory, gardenmanagedseedinformers.SharedInformerFactory, securityinformers.SharedInformerFactory, error) {
+func setupInformerFactories(kubeconfigPath string) (gardencoreinformers.SharedInformerFactory, gardenmanagedseedinformers.SharedInformerFactory, securityinformers.SharedInformerFactory, error) {
 	restConfig, err := newClientConfig(kubeconfigPath)
 	if err != nil {
 		return nil, nil, nil, err

--- a/cmd/gardener-metrics-exporter/app.go
+++ b/cmd/gardener-metrics-exporter/app.go
@@ -15,6 +15,8 @@ import (
 	"github.com/gardener/gardener-metrics-exporter/pkg/version"
 	clientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	securityclientset "github.com/gardener/gardener/pkg/client/security/clientset/versioned"
+	securityinformers "github.com/gardener/gardener/pkg/client/security/informers/externalversions"
 	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
 	gardenmanagedseedinformers "github.com/gardener/gardener/pkg/client/seedmanagement/informers/externalversions"
 
@@ -84,18 +86,19 @@ func run(ctx context.Context, o *options) error {
 	stopCh := make(chan struct{})
 
 	// Create informer factories to create informers.
-	gardenInformerFactory, gardenManagedSeedInformerFactory, err := setupInformerFactories(o.kubeconfigPath, stopCh)
+	gardenInformerFactory, gardenManagedSeedInformerFactory, gardenSecurityInformerFactory, err := setupInformerFactories(o.kubeconfigPath, stopCh)
 	if err != nil {
 		return err
 	}
 
 	// Create informers.
 	var (
-		managedSeedInformer   = gardenManagedSeedInformerFactory.Seedmanagement().V1alpha1().ManagedSeeds().Informer()
-		shootInformer         = gardenInformerFactory.Core().V1beta1().Shoots().Informer()
-		seedInformer          = gardenInformerFactory.Core().V1beta1().Seeds().Informer()
-		projectInformer       = gardenInformerFactory.Core().V1beta1().Projects().Informer()
-		secretBindingInformer = gardenInformerFactory.Core().V1beta1().SecretBindings().Informer()
+		managedSeedInformer        = gardenManagedSeedInformerFactory.Seedmanagement().V1alpha1().ManagedSeeds().Informer()
+		shootInformer              = gardenInformerFactory.Core().V1beta1().Shoots().Informer()
+		seedInformer               = gardenInformerFactory.Core().V1beta1().Seeds().Informer()
+		projectInformer            = gardenInformerFactory.Core().V1beta1().Projects().Informer()
+		secretBindingInformer      = gardenInformerFactory.Core().V1beta1().SecretBindings().Informer()
+		credentialsBindingInformer = gardenSecurityInformerFactory.Security().V1alpha1().CredentialsBindings().Informer()
 	)
 
 	// Start the factories and wait until the informers have synced.
@@ -107,6 +110,11 @@ func run(ctx context.Context, o *options) error {
 	gardenManagedSeedInformerFactory.Start((stopCh))
 	if !cache.WaitForCacheSync(ctx.Done(), managedSeedInformer.HasSynced) {
 		return errors.New("Timed out waiting for Managed Seed caches to sync")
+	}
+
+	gardenSecurityInformerFactory.Start(stopCh)
+	if !cache.WaitForCacheSync(ctx.Done(), credentialsBindingInformer.HasSynced) {
+		return errors.New("Timed out waiting for Security caches to sync")
 	}
 
 	// Start the metrics collector
@@ -159,30 +167,38 @@ func newClientConfig(kubeconfigPath string) (*rest.Config, error) {
 	return client, nil
 }
 
-func setupInformerFactories(kubeconfigPath string, stopCh <-chan struct{}) (gardencoreinformers.SharedInformerFactory, gardenmanagedseedinformers.SharedInformerFactory, error) {
+func setupInformerFactories(kubeconfigPath string, stopCh <-chan struct{}) (gardencoreinformers.SharedInformerFactory, gardenmanagedseedinformers.SharedInformerFactory, securityinformers.SharedInformerFactory, error) {
 	restConfig, err := newClientConfig(kubeconfigPath)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if restConfig == nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	gardenClient, err := clientset.NewForConfig(restConfig)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if gardenClient == nil {
-		return nil, nil, errors.New("gardenClient is nil")
+		return nil, nil, nil, errors.New("gardenClient is nil")
 	}
 	var gardenManagedSeedClient *seedmanagementclientset.Clientset
 	if gardenManagedSeedClient, err = seedmanagementclientset.NewForConfig(restConfig); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if gardenManagedSeedClient == nil {
-		return nil, nil, errors.New("gardenManagedSeedClient is nil")
+		return nil, nil, nil, errors.New("gardenManagedSeedClient is nil")
+	}
+	gardenSecurityClient, err := securityclientset.NewForConfig(restConfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if gardenSecurityClient == nil {
+		return nil, nil, nil, errors.New("gardenSecurityClient is nil")
 	}
 
 	gardenInformerFactory := gardencoreinformers.NewSharedInformerFactory(gardenClient, 0)
 	gardenManagedSeedInformerFactory := gardenmanagedseedinformers.NewSharedInformerFactory(gardenManagedSeedClient, 0)
-	return gardenInformerFactory, gardenManagedSeedInformerFactory, nil
+	securityInformerFactory := securityinformers.NewSharedInformerFactory(gardenSecurityClient, 0)
+	return gardenInformerFactory, gardenManagedSeedInformerFactory, securityInformerFactory, nil
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,6 +6,7 @@ package metrics
 
 import (
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
+	gardensecurityinformers "github.com/gardener/gardener/pkg/client/security/informers/externalversions/security/v1alpha1"
 	gardenmanagedseedinformers "github.com/gardener/gardener/pkg/client/seedmanagement/informers/externalversions/seedmanagement/v1alpha1"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -273,13 +274,14 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 }
 
 type gardenMetricsCollector struct {
-	managedSeedInformer   gardenmanagedseedinformers.ManagedSeedInformer
-	shootInformer         gardencoreinformers.ShootInformer
-	seedInformer          gardencoreinformers.SeedInformer
-	projectInformer       gardencoreinformers.ProjectInformer
-	secretBindingInformer gardencoreinformers.SecretBindingInformer
-	descs                 map[string]*prometheus.Desc
-	logger                *logrus.Logger
+	managedSeedInformer        gardenmanagedseedinformers.ManagedSeedInformer
+	shootInformer              gardencoreinformers.ShootInformer
+	seedInformer               gardencoreinformers.SeedInformer
+	projectInformer            gardencoreinformers.ProjectInformer
+	secretBindingInformer      gardencoreinformers.SecretBindingInformer
+	credentialsBindingInformer gardensecurityinformers.CredentialsBindingInformer
+	descs                      map[string]*prometheus.Desc
+	logger                     *logrus.Logger
 }
 
 // Describe implements the prometheus.Describe interface, which intends the gardenMetricsCollector to be a Prometheus collector.
@@ -300,15 +302,16 @@ func (c *gardenMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 // SetupMetricsCollector takes informers to configure the metrics collectors.
-func SetupMetricsCollector(shootInformer gardencoreinformers.ShootInformer, seedInformer gardencoreinformers.SeedInformer, projectInformer gardencoreinformers.ProjectInformer, managedSeedInformer gardenmanagedseedinformers.ManagedSeedInformer, secretBindingInformer gardencoreinformers.SecretBindingInformer, logger *logrus.Logger) {
+func SetupMetricsCollector(shootInformer gardencoreinformers.ShootInformer, seedInformer gardencoreinformers.SeedInformer, projectInformer gardencoreinformers.ProjectInformer, managedSeedInformer gardenmanagedseedinformers.ManagedSeedInformer, secretBindingInformer gardencoreinformers.SecretBindingInformer, credentialsBindingInformer gardensecurityinformers.CredentialsBindingInformer, logger *logrus.Logger) {
 	metricsCollector := gardenMetricsCollector{
-		managedSeedInformer:   managedSeedInformer,
-		shootInformer:         shootInformer,
-		seedInformer:          seedInformer,
-		projectInformer:       projectInformer,
-		secretBindingInformer: secretBindingInformer,
-		descs:                 getGardenMetricsDefinitions(),
-		logger:                logger,
+		managedSeedInformer:        managedSeedInformer,
+		shootInformer:              shootInformer,
+		seedInformer:               seedInformer,
+		projectInformer:            projectInformer,
+		secretBindingInformer:      secretBindingInformer,
+		credentialsBindingInformer: credentialsBindingInformer,
+		descs:                      getGardenMetricsDefinitions(),
+		logger:                     logger,
 	}
 	prometheus.MustRegister(&metricsCollector)
 	prometheus.MustRegister(ScrapeFailures)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the metrics collection logic to support `CredentialsBinding` as a valid way to identify shoot cost objects. Shoot cost objects are now collected based on either `CredentialsBinding` or `SecretBinding` reference. For the time being, both need to be supported. However, `SecretBindings` will eventually become deprecated. 

**Special notes for your reviewer**:

/cc @istvanballok @chrkl 

**Release note**:

```improvement operator
Add support for `CredentialsBinding` to identify shoot cost objects
```