### PR TITLE
added missing api group security.gardener.cloud to the clusterrole.yaml

### DIFF
--- a/charts/gardener-metrics-exporter/charts/application/templates/clusterrole.yaml
+++ b/charts/gardener-metrics-exporter/charts/application/templates/clusterrole.yaml
@@ -22,3 +22,11 @@ rules:
   - get
   - watch
   - list
+- apiGroups: 
+  - security.gardener.cloud
+  resources:
+  - credentialsbindings
+  verbs:
+  - get
+  - watch 
+  - list


### PR DESCRIPTION
**What this PR does / why we need it**:
After a recent change the Helm chart no longer worked the error indicated that this apiGroup was missing so it was added in and now it works again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```