### PR TITLE
Add new labels for garden_shoot_condition

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -113,6 +113,8 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 				"condition",
 				"operation",
 				"purpose",
+				"reason",
+				"component",
 				"is_seed",
 				"iaas",
 				"seed",


### PR DESCRIPTION
**What this PR does / why we need it**:
For metric `garden_shoot_condition`, the condition could be following list: 
- apiServerAvailable            
- controlPlaneHealthy        
- observabilityComponentsHealthy 
- systemComponentsHealthy     
- everyNodeReady  

There would be various components of controlPlane or systemComponents, when these conditions under False(unhealthy), it is impossible to know the exact failure component. 
This PR is to add new label `reason` and `component` label dynamically extracts specific details from the `condition.Message` based on the `condition.Reason`. 

Reference of the shoot health check definition: https://github.com/gardener/gardener/blob/d7f6fb8d673e7906f5832be8e00a786185701039/pkg/gardenlet/controller/shoot/care/health.go#L519

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```