### PR TITLE
Adding iaas related labels to seed condition metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -55,6 +55,8 @@ func getGardenMetricsDefinitions() map[string]*prometheus.Desc {
 			[]string{
 				"name",
 				"condition",
+				"iaas",
+				"region",
 			},
 			nil,
 		),

--- a/pkg/metrics/seed.go
+++ b/pkg/metrics/seed.go
@@ -124,42 +124,45 @@ func (c gardenMetricsCollector) collectSeedMetrics(ch chan<- prometheus.Metric) 
 		}
 
 		generateSeedConditionMetrics(seed, c.descs[metricGardenSeedCondition], ch)
+		generateSeedOperationStateMetrics(seed, c.descs[metricGardenSeedOperationState], ch)
+	}
+}
 
-		// Export operation state metrics for the Seed.
-		if seed.Status.LastOperation != nil {
-			lastOperation := string(seed.Status.LastOperation.Type)
-			for _, operation := range seedOperations {
-				var operationState float64
-				if operation == lastOperation {
-					switch seed.Status.LastOperation.State {
-					case gardenv1beta1.LastOperationStateSucceeded:
-						operationState = 1
-					case gardenv1beta1.LastOperationStateProcessing:
-						operationState = 2
-					case gardenv1beta1.LastOperationStatePending:
-						operationState = 3
-					case gardenv1beta1.LastOperationStateAborted:
-						operationState = 4
-					case gardenv1beta1.LastOperationStateError:
-						operationState = 5
-					case gardenv1beta1.LastOperationStateFailed:
-						operationState = 6
-					}
-				}
-				metric, err := prometheus.NewConstMetric(
-					c.descs[metricGardenSeedOperationState],
-					prometheus.GaugeValue,
-					operationState,
-					seed.Name,
-					operation,
-				)
-				if err != nil {
-					ScrapeFailures.With(prometheus.Labels{"kind": "seeds"}).Inc()
-					continue
-				}
-				ch <- metric
+func generateSeedOperationStateMetrics(seed *gardenv1beta1.Seed, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
+	if seed.Status.LastOperation == nil {
+		return
+	}
+	lastOperation := string(seed.Status.LastOperation.Type)
+	for _, operation := range seedOperations {
+		var operationState float64
+		if operation == lastOperation {
+			switch seed.Status.LastOperation.State {
+			case gardenv1beta1.LastOperationStateSucceeded:
+				operationState = 1
+			case gardenv1beta1.LastOperationStateProcessing:
+				operationState = 2
+			case gardenv1beta1.LastOperationStatePending:
+				operationState = 3
+			case gardenv1beta1.LastOperationStateAborted:
+				operationState = 4
+			case gardenv1beta1.LastOperationStateError:
+				operationState = 5
+			case gardenv1beta1.LastOperationStateFailed:
+				operationState = 6
 			}
 		}
+		metric, err := prometheus.NewConstMetric(
+			desc,
+			prometheus.GaugeValue,
+			operationState,
+			seed.Name,
+			operation,
+		)
+		if err != nil {
+			ScrapeFailures.With(prometheus.Labels{"kind": "seeds"}).Inc()
+			continue
+		}
+		ch <- metric
 	}
 }
 

--- a/pkg/metrics/seed.go
+++ b/pkg/metrics/seed.go
@@ -124,14 +124,6 @@ func (c gardenMetricsCollector) collectSeedMetrics(ch chan<- prometheus.Metric) 
 		}
 
 		generateSeedConditionMetrics(seed, c.descs[metricGardenSeedCondition], ch)
-	}
-}
-
-func generateSeedConditionMetrics(seed *gardenv1beta1.Seed, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
-	for _, condition := range seed.Status.Conditions {
-		if condition.Type == "" {
-			continue
-		}
 
 		// Export operation state metrics for the Seed.
 		if seed.Status.LastOperation != nil {
@@ -168,6 +160,30 @@ func generateSeedConditionMetrics(seed *gardenv1beta1.Seed, desc *prometheus.Des
 				ch <- metric
 			}
 		}
+	}
+}
+
+func generateSeedConditionMetrics(seed *gardenv1beta1.Seed, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
+	for _, condition := range seed.Status.Conditions {
+		if condition.Type == "" {
+			continue
+		}
+		metric, err := prometheus.NewConstMetric(
+			desc,
+			prometheus.GaugeValue,
+			mapConditionStatus(condition.Status),
+			[]string{
+				seed.Name,
+				string(condition.Type),
+				seed.Spec.Provider.Type,
+				seed.Spec.Provider.Region,
+			}...,
+		)
+		if err != nil {
+			ScrapeFailures.With(prometheus.Labels{"kind": "seeds"}).Inc()
+			continue
+		}
+		ch <- metric
 	}
 }
 

--- a/pkg/metrics/seed.go
+++ b/pkg/metrics/seed.go
@@ -123,25 +123,14 @@ func (c gardenMetricsCollector) collectSeedMetrics(ch chan<- prometheus.Metric) 
 			ch <- metric
 		}
 
-		// Export a metric for each condition of the Seed.
-		for _, condition := range seed.Status.Conditions {
-			if condition.Type == "" {
-				continue
-			}
-			metric, err := prometheus.NewConstMetric(
-				c.descs[metricGardenSeedCondition],
-				prometheus.GaugeValue,
-				mapConditionStatus(condition.Status),
-				[]string{
-					seed.Name,
-					string(condition.Type),
-				}...,
-			)
-			if err != nil {
-				ScrapeFailures.With(prometheus.Labels{"kind": "seeds"}).Inc()
-				continue
-			}
-			ch <- metric
+		generateSeedConditionMetrics(seed, c.descs[metricGardenSeedCondition], ch)
+	}
+}
+
+func generateSeedConditionMetrics(seed *gardenv1beta1.Seed, desc *prometheus.Desc, ch chan<- prometheus.Metric) {
+	for _, condition := range seed.Status.Conditions {
+		if condition.Type == "" {
+			continue
 		}
 
 		// Export operation state metrics for the Seed.

--- a/pkg/metrics/seed_test.go
+++ b/pkg/metrics/seed_test.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"testing"
+
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_generateSeedConditionMetrics(t *testing.T) {
+	seed := &gardenv1beta1.Seed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-seed",
+		},
+		Spec: gardenv1beta1.SeedSpec{
+			Provider: gardenv1beta1.SeedProvider{
+				Type:   "aws",
+				Region: "eu-west-1",
+			},
+		},
+		Status: gardenv1beta1.SeedStatus{
+			Conditions: []gardenv1beta1.Condition{
+				{
+					Type:   "GardenletReady",
+					Status: gardenv1beta1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	desc := prometheus.NewDesc(
+		metricGardenSeedCondition,
+		"Condition state of a Seed. Possible values: -1=Unknown|0=Unhealthy|1=Healthy|2=Progressing",
+		[]string{"name", "condition", "iaas", "region"},
+		nil,
+	)
+
+	ch := make(chan prometheus.Metric, 1)
+	generateSeedConditionMetrics(seed, desc, ch)
+
+	metric := <-ch
+
+	expected, _ := prometheus.NewConstMetric(
+		desc,
+		prometheus.GaugeValue,
+		1, // ConditionTrue → Healthy
+		"test-seed", "GardenletReady", "aws", "eu-west-1",
+	)
+
+	assert(t, expected, metric)
+}
+
+func Test_generateSeedConditionMetrics_skipsEmptyConditionType(t *testing.T) {
+	seed := &gardenv1beta1.Seed{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-seed"},
+		Spec: gardenv1beta1.SeedSpec{
+			Provider: gardenv1beta1.SeedProvider{Type: "gcp", Region: "us-east1"},
+		},
+		Status: gardenv1beta1.SeedStatus{
+			Conditions: []gardenv1beta1.Condition{
+				{Type: "", Status: gardenv1beta1.ConditionTrue},
+			},
+		},
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	generateSeedConditionMetrics(seed, nil, ch)
+
+	if len(ch) != 0 {
+		t.Errorf("expected no metrics for empty condition type, got %d", len(ch))
+	}
+}

--- a/pkg/metrics/seed_test.go
+++ b/pkg/metrics/seed_test.go
@@ -14,9 +14,7 @@ import (
 
 func Test_generateSeedConditionMetrics(t *testing.T) {
 	seed := &gardenv1beta1.Seed{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-seed",
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-seed"},
 		Spec: gardenv1beta1.SeedSpec{
 			Provider: gardenv1beta1.SeedProvider{
 				Type:   "aws",
@@ -43,16 +41,10 @@ func Test_generateSeedConditionMetrics(t *testing.T) {
 	ch := make(chan prometheus.Metric, 1)
 	generateSeedConditionMetrics(seed, desc, ch)
 
-	metric := <-ch
-
-	expected, _ := prometheus.NewConstMetric(
-		desc,
-		prometheus.GaugeValue,
-		1, // ConditionTrue → Healthy
+	expected, _ := prometheus.NewConstMetric(desc, prometheus.GaugeValue, 1,
 		"test-seed", "GardenletReady", "aws", "eu-west-1",
 	)
-
-	assert(t, expected, metric)
+	assert(t, expected, <-ch)
 }
 
 func Test_generateSeedConditionMetrics_skipsEmptyConditionType(t *testing.T) {
@@ -73,5 +65,121 @@ func Test_generateSeedConditionMetrics_skipsEmptyConditionType(t *testing.T) {
 
 	if len(ch) != 0 {
 		t.Errorf("expected no metrics for empty condition type, got %d", len(ch))
+	}
+}
+
+func Test_generateSeedOperationStateMetrics_nilLastOperation(t *testing.T) {
+	seed := &gardenv1beta1.Seed{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-seed"},
+		Spec: gardenv1beta1.SeedSpec{
+			Provider: gardenv1beta1.SeedProvider{Type: "aws", Region: "eu-west-1"},
+		},
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	generateSeedOperationStateMetrics(seed, nil, ch)
+
+	if len(ch) != 0 {
+		t.Errorf("expected no metrics for nil LastOperation, got %d", len(ch))
+	}
+}
+
+func Test_generateSeedOperationStateMetrics_activeOperation(t *testing.T) {
+	seed := &gardenv1beta1.Seed{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-seed"},
+		Spec: gardenv1beta1.SeedSpec{
+			Provider: gardenv1beta1.SeedProvider{Type: "aws", Region: "eu-west-1"},
+		},
+		Status: gardenv1beta1.SeedStatus{
+			LastOperation: &gardenv1beta1.LastOperation{
+				Type:  gardenv1beta1.LastOperationTypeReconcile,
+				State: gardenv1beta1.LastOperationStateSucceeded,
+			},
+		},
+	}
+
+	desc := prometheus.NewDesc(
+		metricGardenSeedOperationState,
+		"Operation state of a Seed.",
+		[]string{"name", "operation"},
+		nil,
+	)
+
+	ch := make(chan prometheus.Metric, len(seedOperations))
+	generateSeedOperationStateMetrics(seed, desc, ch)
+
+	if len(ch) != len(seedOperations) {
+		t.Fatalf("expected %d metrics, got %d", len(seedOperations), len(ch))
+	}
+
+	// seedOperations iteration order is deterministic; build expected values accordingly.
+	expectedValues := map[string]float64{
+		string(gardenv1beta1.LastOperationTypeCreate):    0,
+		string(gardenv1beta1.LastOperationTypeReconcile): 1, // Succeeded
+		string(gardenv1beta1.LastOperationTypeDelete):    0,
+		string(gardenv1beta1.LastOperationTypeMigrate):   0,
+		string(gardenv1beta1.LastOperationTypeRestore):   0,
+	}
+
+	for _, operation := range seedOperations {
+		expected, _ := prometheus.NewConstMetric(desc, prometheus.GaugeValue,
+			expectedValues[string(operation)],
+			"test-seed", string(operation),
+		)
+		assert(t, expected, <-ch)
+	}
+}
+
+func Test_generateSeedOperationStateMetrics_stateMapping(t *testing.T) {
+	cases := []struct {
+		state    gardenv1beta1.LastOperationState
+		expected float64
+	}{
+		{gardenv1beta1.LastOperationStateSucceeded, 1},
+		{gardenv1beta1.LastOperationStateProcessing, 2},
+		{gardenv1beta1.LastOperationStatePending, 3},
+		{gardenv1beta1.LastOperationStateAborted, 4},
+		{gardenv1beta1.LastOperationStateError, 5},
+		{gardenv1beta1.LastOperationStateFailed, 6},
+	}
+
+	desc := prometheus.NewDesc(
+		metricGardenSeedOperationState,
+		"Operation state of a Seed.",
+		[]string{"name", "operation"},
+		nil,
+	)
+
+	for _, tc := range cases {
+		seed := &gardenv1beta1.Seed{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-seed"},
+			Spec: gardenv1beta1.SeedSpec{
+				Provider: gardenv1beta1.SeedProvider{Type: "aws", Region: "eu-west-1"},
+			},
+			Status: gardenv1beta1.SeedStatus{
+				LastOperation: &gardenv1beta1.LastOperation{
+					Type:  gardenv1beta1.LastOperationTypeReconcile,
+					State: tc.state,
+				},
+			},
+		}
+
+		ch := make(chan prometheus.Metric, len(seedOperations))
+		generateSeedOperationStateMetrics(seed, desc, ch)
+
+		// Drain until we find the Reconcile metric (second in seedOperations order).
+		var reconcileMetric prometheus.Metric
+		for _, op := range seedOperations {
+			m := <-ch
+			if string(op) == string(gardenv1beta1.LastOperationTypeReconcile) {
+				reconcileMetric = m
+			}
+		}
+
+		expected, _ := prometheus.NewConstMetric(desc, prometheus.GaugeValue,
+			tc.expected,
+			"test-seed", string(gardenv1beta1.LastOperationTypeReconcile),
+		)
+		assert(t, expected, reconcileMetric)
 	}
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Adding iaas related labels to seed condition metrics. Also added some unit tests for both the seed condition metric and operation state metrics (tests are generated with claude code)

This is useful since, as SRE, we need to see trends when multiple problems happen. By adding this `iaas` and `region` labels, it make it way easier for us to generate reporting and see problems frequencies by iaas (which is a notorious source of production issues).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Adding iaas related labels to seed condition metric
```